### PR TITLE
Set up file structure for concrete model

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -9,3 +9,4 @@ src/Concrete/Assumptions/ArchMM.v
 src/Concrete/Assumptions/Constants.v
 src/Concrete/Assumptions/Datatypes.v
 src/Concrete/Assumptions/Mpool.v
+src/Concrete/Assumptions/PageTables.v

--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -2,6 +2,8 @@
 src/AbstractModel.v
 src/Concrete/ConcreteModel.v
 src/Concrete/Datatypes.v
+src/Concrete/Notations.v
+src/Concrete/State.v
 src/Util/List.v
 src/Util/Tactics.v
 src/Concrete/Assumptions/Addr.v

--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -1,5 +1,11 @@
 -R src/ Hafnium
 src/AbstractModel.v
 src/Concrete/ConcreteModel.v
+src/Concrete/Datatypes.v
 src/Util/List.v
 src/Util/Tactics.v
+src/Concrete/Assumptions/Addr.v
+src/Concrete/Assumptions/ArchMM.v
+src/Concrete/Assumptions/Constants.v
+src/Concrete/Assumptions/Datatypes.v
+src/Concrete/Assumptions/Mpool.v

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -1,0 +1,20 @@
+Require Import Hafnium.Concrete.Datatypes.
+
+(*** This file defines (the necessary parts of) the API provided by addr.h,
+     which is assumed correct for now. In order to replace this assumption with
+     a proof of correctness, replace the [Axiom]s with definitions and proofs,
+     leaving their types the same. ***)
+
+Axiom ipaddr_t : Type.
+
+Axiom paddr_t : Type.
+
+Axiom pa_addr : paddr_t -> uintpaddr_t.
+
+Axiom ipa_addr : ipaddr_t -> uintpaddr_t.
+
+Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.
+
+Axiom pa_from_ipa : ipaddr_t -> paddr_t.
+
+(* TODO: add axioms for correctness properties, as needed *)

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -17,4 +17,6 @@ Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.
 
 Axiom pa_from_ipa : ipaddr_t -> paddr_t.
 
+Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
+
 (* TODO: add axioms for correctness properties, as needed *)

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -1,0 +1,29 @@
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+
+(*** This file defines (the necessary parts of) the API provided by arch/mm.h,
+     which is assumed correct for now. In order to replace this assumption with
+     a proof of correctness, replace the [Axiom]s with definitions and proofs,
+     leaving their types the same. ***)
+
+(* levels are represented by natural numbers, but just to make it
+   extra clear we give them an alias to differentiate them from
+   other [nat]s *)
+Local Notation level := nat.
+
+Axiom arch_mm_absent_pte : level -> pte_t.
+
+Axiom arch_mm_block_pte : level -> paddr_t -> attributes.
+
+Axiom arch_mm_pte_is_present : pte_t -> level -> bool.
+
+Axiom arch_mm_pte_is_valid : pte_t -> level -> bool.
+
+Axiom arch_mm_pte_is_block : pte_t -> level -> bool.
+
+Axiom arch_mm_pte_is_table : pte_t -> level -> bool.
+
+Axiom arch_mm_table_from_pte : pte_t -> level -> paddr_t.
+
+Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -27,3 +27,7 @@ Axiom arch_mm_pte_is_table : pte_t -> level -> bool.
 Axiom arch_mm_table_from_pte : pte_t -> level -> paddr_t.
 
 Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.
+
+Axiom arch_mm_stage2_attrs_to_mode : attributes -> mode_t.
+
+Axiom arch_mm_stage1_attrs_to_mode : attributes -> mode_t.

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -8,6 +8,9 @@ Import ListNotations.
 (* PAGE_SIZE is a natural number *)
 Axiom PAGE_SIZE : nat.
 
+(* PTEs per page -- natural number *)
+Axiom MM_PTE_PER_PAGE : nat.
+
 (* mm_mode flags are all natural numbers*)
 (* N.B. : mode flags are taken as *indices* in the binary number; this makes it
    easier to state that they are all distinct and makes it true by construction

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -1,0 +1,21 @@
+Require Import Coq.Lists.List.
+Import ListNotations.
+
+(*** This file lists the types and names of constants that we assume are defined
+     in e.g. mm.h. These are left abstract because none of the proofs should
+     depend on their exact values. ***)
+
+(* PAGE_SIZE is a natural number *)
+Axiom PAGE_SIZE : nat.
+
+(* mm_mode flags are all natural numbers*)
+(* N.B. : mode flags are taken as *indices* in the binary number; this makes it
+   easier to state that they are all distinct and makes it true by construction
+   that they each affect only one bit of the overall mode. *)
+Axiom MM_MODE_R MM_MODE_W MM_MODE_X MM_MODE_INVALID MM_MODE_UNOWNED
+      MM_MODE_SHARED : nat.
+
+(* assume that all mode-flag indices are distinct from each other *)
+Axiom mm_modes_distinct :
+  NoDup [MM_MODE_R; MM_MODE_W; MM_MODE_X; MM_MODE_INVALID; MM_MODE_UNOWNED;
+           MM_MODE_SHARED].

--- a/coq-verification/src/Concrete/Assumptions/Datatypes.v
+++ b/coq-verification/src/Concrete/Assumptions/Datatypes.v
@@ -1,0 +1,6 @@
+(*** This file is for datatypes that are left abstract so as to avoid making any
+     assumptions about their content. It may be necessary to instantiate these
+     types later. ***)
+
+(* pointers to page tables *)
+Axiom ptable_pointer : Type.

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -1,0 +1,23 @@
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+
+(*** This file defines (the necessary parts of) the API provided by mpool.h,
+     which is assumed correct for now. In order to replace this assumption with
+     a proof of correctness, replace the [Axiom]s with definitions and proofs,
+     leaving their types the same. ***)
+
+Axiom mpool : Type.
+
+Axiom mpool_init_with_fallback : mpool -> mpool.
+
+(* If there is a fallback, return its new state, otherwise return [None] *)
+Axiom mpool_fini : mpool -> option mpool.
+
+(* If there's a location available, return the new state and the pointer,
+   otherwise return [None] *)
+Axiom mpool_alloc : mpool -> option (mpool * ptable_pointer).
+
+(* Return the new state of the mpool *)
+Axiom mpool_free : mpool -> ptable_pointer -> mpool.
+
+(* TODO: add axioms for correctness properties, as needed *)

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -1,0 +1,19 @@
+Require Import Coq.NArith.BinNat.
+
+(*** This file details how to represent some of the types in the source code
+     using Coq types. ***)
+
+(* an absolute address is represented by a natural number *)
+Definition uintpaddr_t : Type := nat.
+
+(* a size is represented by a natural number *)
+Definition size_t : Type := nat.
+
+(* an int is represented by a *binary* natural number *)
+Definition int := N.
+
+(* attributes (uint64_t) are represented by a binary natural number*)
+Definition attributes := N.
+
+(* a page table entry (uint64_t) is represented by a binary natural number *)
+Definition pte_t := N.

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -1,4 +1,5 @@
 Require Import Coq.NArith.BinNat.
+Require Import Coq.Lists.List.
 
 (*** This file details how to represent some of the types in the source code
      using Coq types. ***)
@@ -17,3 +18,6 @@ Definition attributes := N.
 
 (* a page table entry (uint64_t) is represented by a binary natural number *)
 Definition pte_t := N.
+
+(* page tables are a list of PTEs *)
+Definition page_table := list pte_t.

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -4,8 +4,9 @@ Require Import Coq.Lists.List.
 (*** This file details how to represent some of the types in the source code
      using Coq types. ***)
 
-(* an absolute address is represented by a natural number *)
-Definition uintpaddr_t : Type := nat.
+(* absolute addresses are represented by binary natural numbers *)
+Definition uintpaddr_t : Type := N.
+Definition uintvaddr_t : Type := N.
 
 (* a size is represented by a natural number *)
 Definition size_t : Type := nat.
@@ -15,6 +16,9 @@ Definition int := N.
 
 (* attributes (uint64_t) are represented by a binary natural number*)
 Definition attributes := N.
+
+(* memory modes (int) are represented by binary natural numbers *)
+Definition mode_t := N.
 
 (* a page table entry (uint64_t) is represented by a binary natural number *)
 Definition pte_t := N.

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -1,0 +1,24 @@
+Require Import Coq.NArith.BinNat.
+Require Import Hafnium.Concrete.Datatypes.
+
+(*** This file is mostly boilerplate to coerce Coq's notation system into making
+     the model more readable ***)
+
+(* nicer display of mm_mode operations *)
+Definition mm_mode_set_flag (m : int) (flag : nat) : int :=
+  N.setbit m (N.of_nat flag).
+Definition mm_mode_get_flag (m : int) (flag : nat) : bool :=
+  N.testbit m (N.of_nat flag).
+Notation "[ x | .. | y ]" :=
+  (mm_mode_set_flag .. (mm_mode_set_flag 0 x) .. y)
+    (at level 49, y at level 0, only parsing) : N_scope.
+Notation "x & y " :=
+  (mm_mode_get_flag x y)
+    (at level 49, y at level 0, only parsing) : N_scope.
+
+Bind Scope N_scope with mode_t.
+Bind Scope N_scope with attributes.
+Bind Scope N_scope with uintpaddr_t.
+Bind Scope N_scope with uintvaddr_t.
+
+Notation "! x" := (negb x) (at level 200) : bool_scope.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -1,0 +1,106 @@
+Require Import Coq.Lists.List.
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.NArith.BinNat.
+Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.ArchMM.
+Require Import Hafnium.Concrete.Assumptions.Constants.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Assumptions.PageTables.
+Require Import Hafnium.Concrete.Notations.
+
+(*** This file defines the state type for the concrete model and relates it to
+     the abstract state. ***)
+
+Record vm :=
+  {
+    vm_root_ptable : ptable_pointer;
+    id : nat;
+  }.
+
+(* starting parameters -- don't change *)
+Class concrete_params :=
+  {
+    vms : list vm;
+    hafnium_root_ptable : ptable_pointer;
+  }.
+
+Record concrete_state :=
+  {
+    (* representation of the state of page tables in memory *)
+    ptable_lookup : ptable_pointer -> page_table;
+    api_page_pool : mpool;
+  }.
+
+Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
+  (* Possible constraints:
+        - Block PTEs have the valid bit set
+        - page tables have a constant size
+        - page table indices are always below page table size
+        - vm_id corresponds to a VM's place in the vms list
+   *)
+  True.
+
+Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=
+  find (fun v => (v.(id) =? vid)) vms.
+
+Definition vm_page_valid (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
+  exists e : pte_t,
+    page_lookup s.(ptable_lookup) v.(vm_root_ptable) a.(pa_addr) = Some e
+    /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
+
+Definition haf_page_valid
+           {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
+  exists e : pte_t,
+    page_lookup s.(ptable_lookup) hafnium_root_ptable a.(pa_addr) = Some e
+    /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
+
+Local Definition owned (mode : mode_t) : Prop :=
+  (mode & MM_MODE_UNOWNED)%N = false.
+
+Definition vm_page_owned (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
+  exists e : pte_t,
+    page_lookup s.(ptable_lookup) v.(vm_root_ptable) a.(pa_addr) = Some e
+    /\ forall lvl,
+      owned (arch_mm_stage2_attrs_to_mode (arch_mm_pte_attrs e lvl)).
+
+Definition haf_page_owned
+           {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
+  exists e : pte_t,
+    page_lookup s.(ptable_lookup) hafnium_root_ptable a.(pa_addr) = Some e
+    /\ forall lvl,
+      owned (arch_mm_stage1_attrs_to_mode (arch_mm_pte_attrs e lvl)).
+
+Arguments owned_by {_} {_} _.
+Arguments accessible_by {_} {_} _.
+Definition represents
+           {cp : concrete_params}
+           (abst : @abstract_state paddr_t nat)
+           (conc : concrete_state) : Prop :=
+  is_valid conc
+  /\ (forall (vid : nat) (a : paddr_t),
+      In (inl vid) (abst.(accessible_by) a) <->
+         (exists v : vm,
+             vm_find vid = Some v /\ conc.(vm_page_valid) v a))
+  /\ (forall (a : paddr_t),
+         In (inr hid) (abst.(accessible_by) a) <-> conc.(haf_page_valid) a)
+  /\ (forall (vid : nat) (a : paddr_t),
+         abst.(owned_by) a = inl vid <->
+         (exists v : vm,
+             vm_find vid = Some v /\ conc.(vm_page_owned) v a))
+  /\ (forall (a : paddr_t),
+         abst.(owned_by) a = inr hid <-> conc.(haf_page_owned) a)
+.
+
+Definition abstract_state_equiv
+           (s1 s2 : @abstract_state paddr_t nat) : Prop :=
+  (forall a, s1.(owned_by) a = s2.(owned_by) a)
+  /\ (forall e a,
+         In e (s1.(accessible_by) a) <-> In e (s2.(accessible_by) a)).
+
+(* for every API function, we need to prove that if the concrete state (is
+   itself valid and) represents a valid abstract state before the call, then
+   the concrete state after the call (is also valid and) represents a valid
+   abstract state *)


### PR DESCRIPTION
Previously, I had the concrete model all in one file, and it wasn't exactly clear what was part of the TCB and what was part of various different layers of abstraction. My previous setup also diverged from the code in several places in terms of how it handled success/failure and what I called address types. I have fixed both issues with the following steps:

- Made my functions return success/failure booleans instead of the `option` monad
- Changed my address-type names so they match the code
- Created a new subdirectory Concrete/Assumptions where I put the interfaces to all of the files that aren't currently in scope. These are transcribed as directly as possible from the header files; functions have the same names and type signatures (except where functional programming requires me to return a new state, like for mpool).

I modified `ConcreteModel.v` to use the new setup. The most substantial lines-of-code changes here are my moving some of the code from `ConcreteModel.v` into a new file `State.v` that sets up the concrete model's state type, so that `ConcreteModel.v` has almost nothing but transcriptions of C functions.

Eventually, I aim to get rid of `ConcreteModel.v` entirely and separate out the transcriptions into files corresponding to `mm.c` and `api.c`, but that is left for a later PR.