### PR TITLE
Minor cleanup of ConcreteModel

### DIFF
--- a/coq-verification/src/Concrete/ConcreteModel.v
+++ b/coq-verification/src/Concrete/ConcreteModel.v
@@ -90,9 +90,6 @@ Section Concrete.
              (ppool : mpool) : (bool * concrete_state * mpool) :=
     (false, s, ppool).
 
-  Definition mpool_fini (s : concrete_state) (ppool : mpool)
-    : concrete_state := s. (* TODO *)
-
   (*
     /**
     * Clears a region of physical memory by overwriting it with zeros. The data is
@@ -346,8 +343,8 @@ Section Concrete.
                           FAIL
                         | (true, new_state, new_local_page_pool) =>
                           let state := new_state in
-                        let local_page_pool := new_local_page_pool in
-                        (*
+                          let local_page_pool := new_local_page_pool in
+                          (*
                                   ret = 0;
                                   goto out;
                           out:
@@ -355,16 +352,24 @@ Section Concrete.
                                   sl_unlock(&to->lock);
                                   mpool_fini(&local_page_pool);
                                   return ret;
-                         *)
-                        let state := mpool_fini state local_page_pool in
-                        (true, state)
+                           *)
+                          match mpool_fini local_page_pool with
+                          | Some new_api_page_pool =>
+                            (* update api pool and return success + new state *)
+                            let state :=
+                                {|
+                                  ptable_lookup := state.(ptable_lookup);
+                                  api_page_pool := new_api_page_pool;
+                                |} in
+                            (true, state)
+                          | None => FAIL
+                          end
                         end
                       end
                     end
-              
             end
           end
-  end.
+      end.
 
 End Concrete.
 

--- a/coq-verification/src/Concrete/ConcreteModel.v
+++ b/coq-verification/src/Concrete/ConcreteModel.v
@@ -14,13 +14,6 @@ Import ListNotations.
 (*** Low-level model : describes the concrete state of the Hafnium system ***)
 
 Section Concrete.
-  (* hf_share enum *)
-  Inductive hf_share :=
-  | HF_MEMORY_GIVE
-  | HF_MEMORY_LEND
-  | HF_MEMORY_SHARE
-  | INVALID
-  .
 
   Definition ptable_addr_t : Type := uintvaddr_t.
   Bind Scope N_scope with ptable_addr_t.

--- a/coq-verification/src/Concrete/ConcreteModel.v
+++ b/coq-verification/src/Concrete/ConcreteModel.v
@@ -23,11 +23,7 @@ Section Concrete.
   .
 
   Definition ptable_addr_t : Type := uintvaddr_t.
-
-  (* boilerplate for readability *)
   Bind Scope N_scope with ptable_addr_t.
-  Local Coercion N.of_nat : nat >-> N. (* change nat to N automatically *)
-  Set Printing Coercions. (* when printing, show N.of_nat explicitly *)
 
   (*
     static ptable_addr_t mm_round_down_to_page(ptable_addr_t addr)

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -25,3 +25,11 @@ Definition pte_t := N.
 
 (* page tables are a list of PTEs *)
 Definition page_table := list pte_t.
+
+(* hf_share enum *)
+Inductive hf_share :=
+| HF_MEMORY_GIVE
+| HF_MEMORY_LEND
+| HF_MEMORY_SHARE
+| INVALID
+.

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -22,3 +22,6 @@ Bind Scope N_scope with uintpaddr_t.
 Bind Scope N_scope with uintvaddr_t.
 
 Notation "! x" := (negb x) (at level 200) : bool_scope.
+
+Coercion N.of_nat : nat >-> N. (* change nat to N automatically *)
+Set Printing Coercions. (* when printing, show N.of_nat explicitly *)


### PR DESCRIPTION
On top of #7 

Moves `hf_share` and some notation magic to the new files that they now belong to. Also fixes `mpool_fini`, which in #7 was accidentally still using a version in ConcreteModel instead of the new one in `MM/Implementation.v`.

This is small enough that I will plan to merge it without review.