### PR TITLE
Use a stub of mm_vm_defrag (minor change)

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -11,5 +11,6 @@ src/Concrete/Assumptions/Constants.v
 src/Concrete/Assumptions/Datatypes.v
 src/Concrete/Assumptions/Mpool.v
 src/Concrete/Assumptions/PageTables.v
+src/Concrete/MM/Datatypes.v
 src/Concrete/MM/Implementation.v
 src/Concrete/Api/Implementation.v

--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -32,7 +32,7 @@ int64_t api_share_memory(spci_vm_id_t vm_id, ipaddr_t addr, size_t size,
 Definition api_share_memory
            {cp : concrete_params}
            (state : concrete_state)
-           (vm_id : nat)
+           (vid : nat) (* named [vid] because [vm_id] is a field name in [vm] *)
            (addr : ipaddr_t)
            (size : size_t)
            (share : hf_share)
@@ -94,7 +94,7 @@ Definition api_share_memory
        return -1;
     }
    *)
-  if (vm_id =? from.(id))
+  if (vid =? from.(vm_id))
   then (false, state)
   else
     (*
@@ -104,7 +104,7 @@ Definition api_share_memory
               return -1;
       }
      *)
-    match vm_find vm_id with
+    match vm_find vid with
     | None => (false, state)
     | Some to =>
 

--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -307,8 +307,9 @@ Definition api_share_memory
                                                pa_end
                                                to_mode
                                                local_page_pool with
-                      | (false, new_state, new_local_page_pool) =>
-                        (* TODO: defrag *)
+                      | (false, state, local_page_pool) =>
+                        let '(_, state, local_page_pool) :=
+                            mm_vm_defrag state from.(vm_root_ptable) local_page_pool in
                         goto_fail_return_to_sender
                           new_state
                           new_local_page_pool

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -4,6 +4,7 @@ Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
 Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.MM.Datatypes.
 
 (*** This file encodes in Coq how we expect page table lookups to work. It should
      be considered part of the TCB, because the proofs rely on this transcription

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -25,10 +25,10 @@ Axiom offset : uintpaddr_t -> nat.
 Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
 
 Axiom page_table_size :
-  forall ptable : page_table, length ptable = MM_PTE_PER_PAGE.
+  forall ptable : mm_page_table, length ptable.(entries) = MM_PTE_PER_PAGE.
 
-Definition get_entry (ptable : page_table) (i : nat) : option pte_t :=
-  nth_error ptable i.
+Definition get_entry (ptable : mm_page_table) (i : nat) : option pte_t :=
+  nth_error ptable.(entries) i.
 
 Definition get_index (level : nat) (a : uintpaddr_t) : nat :=
   match level with
@@ -43,7 +43,7 @@ Definition get_index (level : nat) (a : uintpaddr_t) : nat :=
    valid/present; rather, the lookup should return [Some] for any
    valid input, but the PTE returned might be absent or invalid. *)
 Fixpoint page_lookup'
-         (ptable_lookup : ptable_pointer -> page_table)
+         (ptable_lookup : ptable_pointer -> mm_page_table)
          (a : uintpaddr_t)
          (ptr : ptable_pointer)
          (* encode the level as (4 - level), so Coq knows this terminates *)
@@ -68,7 +68,7 @@ Fixpoint page_lookup'
   end.
 
 Definition page_lookup
-           (ptable_lookup : ptable_pointer -> page_table)
+           (ptable_lookup : ptable_pointer -> mm_page_table)
            (root_ptable : ptable_pointer)
            (a : uintpaddr_t) : option pte_t :=
   page_lookup' ptable_lookup a root_ptable 4.

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -30,10 +30,3 @@ Inductive hf_share :=
 | HF_MEMORY_SHARE
 | INVALID
 .
-
-(*
-struct mm_page_table {
-	alignas(PAGE_SIZE) pte_t entries[MM_PTE_PER_PAGE];
-};
- *)
-Record mm_page_table := { entries : list pte_t }.

--- a/coq-verification/src/Concrete/Datatypes.v
+++ b/coq-verification/src/Concrete/Datatypes.v
@@ -23,9 +23,6 @@ Definition mode_t := N.
 (* a page table entry (uint64_t) is represented by a binary natural number *)
 Definition pte_t := N.
 
-(* page tables are a list of PTEs *)
-Definition page_table := list pte_t.
-
 (* hf_share enum *)
 Inductive hf_share :=
 | HF_MEMORY_GIVE
@@ -33,3 +30,10 @@ Inductive hf_share :=
 | HF_MEMORY_SHARE
 | INVALID
 .
+
+(*
+struct mm_page_table {
+	alignas(PAGE_SIZE) pte_t entries[MM_PTE_PER_PAGE];
+};
+ *)
+Record mm_page_table := { entries : list pte_t }.

--- a/coq-verification/src/Concrete/MM/Datatypes.v
+++ b/coq-verification/src/Concrete/MM/Datatypes.v
@@ -1,0 +1,20 @@
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+
+(*** This file transcribes some datatypes found in mm.h, with original C in
+     comments alongside ***)
+
+(*
+struct mm_page_table {
+	alignas(PAGE_SIZE) pte_t entries[MM_PTE_PER_PAGE];
+};
+ *)
+Record mm_page_table := { entries : list pte_t }.
+
+(*
+struct mm_ptable {
+	/** Address of the root of the page table. */
+	paddr_t root;
+};
+ *)
+Record mm_ptable := { root : paddr_t }.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -14,14 +14,6 @@ Require Import Hafnium.Concrete.Assumptions.Mpool.
 Definition ptable_addr_t : Type := uintvaddr_t.
 Bind Scope N_scope with ptable_addr_t.
 
-(*
-struct mm_ptable {
-	/** Address of the root of the page table. */
-	paddr_t root;
-};
- *)
-Record mm_ptable := { root : paddr_t }.
-
 (* static ptable_addr_t mm_round_down_to_page(ptable_addr_t addr) *)
 Definition mm_round_down_to_page (addr : ptable_addr_t) : ptable_addr_t :=
   (* return addr & ~((ptable_addr_t)(PAGE_SIZE - 1)); *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -14,6 +14,17 @@ Require Import Hafnium.Concrete.Assumptions.Mpool.
 Definition ptable_addr_t : Type := uintvaddr_t.
 Bind Scope N_scope with ptable_addr_t.
 
+(*
+struct mm_ptable {
+	/** Address of the root of the page table. */
+	paddr_t root;
+};
+ *)
+Record mm_ptable :=
+  {
+    root : paddr_t;
+  }.
+
 (* static ptable_addr_t mm_round_down_to_page(ptable_addr_t addr) *)
 Definition mm_round_down_to_page (addr : ptable_addr_t) : ptable_addr_t :=
   (* return addr & ~((ptable_addr_t)(PAGE_SIZE - 1)); *)
@@ -81,3 +92,15 @@ Definition mm_vm_identity_map
            (mode : mode_t)
            (ppool : mpool) : (bool * concrete_state * mpool) :=
   (false, s, ppool).
+
+(* TODO: use mm_ptable here and everywhere appropriate (eg vms) *)
+(*
+  /**
+   * Defragments the VM page table.
+   */
+  void mm_vm_defrag(struct mm_ptable *t, struct mpool *ppool)
+  *)
+Definition mm_vm_defrag
+           (s : concrete_state) (t : ptable_pointer) (ppool : mpool)
+  : (bool * concrete_state * mpool) :=
+  (false, s, ppool). (* TODO *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -20,10 +20,7 @@ struct mm_ptable {
 	paddr_t root;
 };
  *)
-Record mm_ptable :=
-  {
-    root : paddr_t;
-  }.
+Record mm_ptable := { root : paddr_t }.
 
 (* static ptable_addr_t mm_round_down_to_page(ptable_addr_t addr) *)
 Definition mm_round_down_to_page (addr : ptable_addr_t) : ptable_addr_t :=
@@ -93,7 +90,6 @@ Definition mm_vm_identity_map
            (ppool : mpool) : (bool * concrete_state * mpool) :=
   (false, s, ppool).
 
-(* TODO: use mm_ptable here and everywhere appropriate (eg vms) *)
 (*
   /**
    * Defragments the VM page table.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -15,11 +15,10 @@ Require Import Hafnium.Concrete.MM.Datatypes.
 (*** This file defines the state type for the concrete model and relates it to
      the abstract state. ***)
 
-(* TODO: make naming more consistent by calling [id] [vm_id] *)
 Record vm :=
   {
     vm_ptable : mm_ptable;
-    id : nat;
+    vm_id : nat;
   }.
 
 Definition vm_root_ptable (v : vm) : ptable_pointer :=
@@ -49,7 +48,7 @@ Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
   True.
 
 Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=
-  find (fun v => (v.(id) =? vid)) vms.
+  find (fun v => (v.(vm_id) =? vid)) vms.
 
 Definition vm_page_valid (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists e : pte_t,

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -30,7 +30,7 @@ Class concrete_params :=
 Record concrete_state :=
   {
     (* representation of the state of page tables in memory *)
-    ptable_lookup : ptable_pointer -> page_table;
+    ptable_lookup : ptable_pointer -> mm_page_table;
     api_page_pool : mpool;
   }.
 

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -15,11 +15,15 @@ Require Import Hafnium.Concrete.MM.Datatypes.
 (*** This file defines the state type for the concrete model and relates it to
      the abstract state. ***)
 
+(* TODO: make naming more consistent by calling [id] [vm_id] *)
 Record vm :=
   {
-    vm_root_ptable : ptable_pointer;
+    vm_ptable : mm_ptable;
     id : nat;
   }.
+
+Definition vm_root_ptable (v : vm) : ptable_pointer :=
+  ptable_pointer_from_address v.(vm_ptable).(root).
 
 (* starting parameters -- don't change *)
 Class concrete_params :=

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -3,13 +3,14 @@ Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.BinNat.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Notations.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
 Require Import Hafnium.Concrete.Assumptions.Datatypes.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
 Require Import Hafnium.Concrete.Assumptions.PageTables.
-Require Import Hafnium.Concrete.Notations.
+Require Import Hafnium.Concrete.MM.Datatypes.
 
 (*** This file defines the state type for the concrete model and relates it to
      the abstract state. ***)


### PR DESCRIPTION
On top of #10 

- Adds a stub definition for `mm_vm_defrag` to resolve a TODO in `api_share_memory`
- replaces the simplified `list pte_t` definition of page tables with a transcription of the `mm_page_table` struct

This is a pretty small change, so I'll plan to merge it once #10 is merged without review.