### PR TITLE
Transcribe api_clear_memory

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -11,6 +11,8 @@ Axiom paddr_t : Type.
 
 Axiom pa_addr : paddr_t -> uintpaddr_t.
 
+Axiom pa_difference : paddr_t -> paddr_t -> size_t.
+
 Axiom ipa_addr : ipaddr_t -> uintpaddr_t.
 
 Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -92,3 +92,31 @@ Definition mm_vm_defrag
            (s : concrete_state) (t : ptable_pointer) (ppool : mpool)
   : (bool * concrete_state * mpool) :=
   (false, s, ppool). (* TODO *)
+
+(*
+  /**
+  * Updates the hypervisor page table such that the given physical address range
+  * is mapped into the address space at the corresponding address range in the
+  * architecture-agnostic mode provided.
+  */
+  void *mm_identity_map(paddr_t begin, paddr_t end, int mode, struct mpool *ppool)
+ *)
+Definition mm_identity_map
+           (s : concrete_state)
+           (begin end_ : paddr_t)
+           (mode : mode_t)
+           (ppool : mpool) : (concrete_state * mpool) :=
+  (s, ppool). (* TODO *)
+
+(*
+  /**
+   * Updates the hypervisor table such that the given physical address range is
+   * not mapped in the address space.
+   */
+  bool mm_unmap(paddr_t begin, paddr_t end, struct mpool *ppool)
+ *)
+Definition mm_unmap (s : concrete_state) (begin end_ : paddr_t) (ppool : mpool)
+  : (bool * concrete_state * mpool) :=
+  (false, s, ppool). (* TODO *)
+
+(* TODO: deindent the C code in this file *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -101,12 +101,15 @@ Definition mm_vm_defrag
   */
   void *mm_identity_map(paddr_t begin, paddr_t end, int mode, struct mpool *ppool)
  *)
+(* N.B. the original code returns a [void *] that is NULL if the operation
+   failed; we will return a boolean instead, since we don't currently ever do
+   anything with the pointer except check if it's NULL. *)
 Definition mm_identity_map
            (s : concrete_state)
            (begin end_ : paddr_t)
            (mode : mode_t)
-           (ppool : mpool) : (concrete_state * mpool) :=
-  (s, ppool). (* TODO *)
+           (ppool : mpool) : (bool * concrete_state * mpool) :=
+  (false, s, ppool). (* TODO *)
 
 (*
   /**
@@ -118,5 +121,15 @@ Definition mm_identity_map
 Definition mm_unmap (s : concrete_state) (begin end_ : paddr_t) (ppool : mpool)
   : (bool * concrete_state * mpool) :=
   (false, s, ppool). (* TODO *)
+
+(*
+/**
+ * Defragments the hypervisor page table.
+ */
+void mm_defrag(struct mpool *ppool)
+ *)
+Definition mm_defrag (s : concrete_state) (ppool : mpool)
+  : (concrete_state * mpool) :=
+  (s, ppool). (* TODO *)
 
 (* TODO: deindent the C code in this file *)


### PR DESCRIPTION
Compared to `api_share_memory`, this one is fairly simple -- especially because we're not currently modelling anything about data contents, only data access rights. So I didn't have to transcribe the part that actually clears the data -- just the part that deals with page table logic.