### PR TITLE
Cleanup in MM/Implementation.v (minor change)

### DIFF
--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -25,16 +25,16 @@ Definition mm_round_up_to_page (addr : ptable_addr_t) : ptable_addr_t :=
   mm_round_down_to_page (addr + PAGE_SIZE - 1).
 
 (*
-  /**
-  * Gets the attributes applies to the given range of addresses in the stage-2
-  * table.
-  *
-  * The value returned in `attrs` is only valid if the function returns true.
-  *
-  * Returns true if the whole range has the same attributes and false otherwise.
-  */
-  static bool mm_vm_get_attrs(struct mm_ptable *t, ptable_addr_t begin,
-                              ptable_addr_t end, uint64_t *attrs)
+/**
+* Gets the attributes applies to the given range of addresses in the stage-2
+* table.
+*
+* The value returned in `attrs` is only valid if the function returns true.
+*
+* Returns true if the whole range has the same attributes and false otherwise.
+*/
+static bool mm_vm_get_attrs(struct mm_ptable *t, ptable_addr_t begin,
+                            ptable_addr_t end, uint64_t *attrs)
  *)
 (* N.B. instead of passing in a page table we pass in the vm whose root table
    we are searching *)
@@ -45,13 +45,13 @@ Definition mm_vm_get_attrs
   (false, 0%N). (* TODO *)
 
 (*
-  /**
-  * Updates a VM's page table such that the given physical address range is
-  * mapped in the address space at the corresponding address range in the
-  * architecture-agnostic mode provided.
-  */
-  bool mm_vm_identity_map(struct mm_ptable *t, paddr_t begin, paddr_t end,
-                          int mode, ipaddr_t *ipa, struct mpool *ppool)
+/**
+* Updates a VM's page table such that the given physical address range is
+* mapped in the address space at the corresponding address range in the
+* architecture-agnostic mode provided.
+*/
+bool mm_vm_identity_map(struct mm_ptable *t, paddr_t begin, paddr_t end,
+                        int mode, ipaddr_t *ipa, struct mpool *ppool)
  *)
 (* N.B. for now, ignoring the ipa argument, which is set to NULL in all calls
    I've found so far. *)
@@ -76,14 +76,14 @@ Definition mm_vm_defrag
   (false, s, ppool). (* TODO *)
 
 (*
-  /**
-  * Gets the mode of the give range of intermediate physical addresses if they
-  * are mapped with the same mode.
-  *
-  * Returns true if the range is mapped with the same mode and false otherwise.
-  */
-  bool mm_vm_get_mode(struct mm_ptable *t, ipaddr_t begin, ipaddr_t end,
-       int *mode)
+/**
+* Gets the mode of the give range of intermediate physical addresses if they
+* are mapped with the same mode.
+*
+* Returns true if the range is mapped with the same mode and false otherwise.
+*/
+bool mm_vm_get_mode(struct mm_ptable *t, ipaddr_t begin, ipaddr_t end,
+     int *mode)
  *)
 (* N.B. the comment above the function means "the entire range of addresses
    has one consistent mode" and not "the range of addresses has the same
@@ -95,12 +95,12 @@ Definition mm_vm_get_mode
   (false, 0%N). (* TODO *)
 
 (*
-  /**
-  * Updates the hypervisor page table such that the given physical address range
-  * is mapped into the address space at the corresponding address range in the
-  * architecture-agnostic mode provided.
-  */
-  void *mm_identity_map(paddr_t begin, paddr_t end, int mode, struct mpool *ppool)
+/**
+* Updates the hypervisor page table such that the given physical address range
+* is mapped into the address space at the corresponding address range in the
+* architecture-agnostic mode provided.
+*/
+void *mm_identity_map(paddr_t begin, paddr_t end, int mode, struct mpool *ppool)
  *)
 (* N.B. the original code returns a [void *] that is NULL if the operation
    failed; we will return a boolean instead, since we don't currently ever do
@@ -113,11 +113,11 @@ Definition mm_identity_map
   (false, s, ppool). (* TODO *)
 
 (*
-  /**
-   * Updates the hypervisor table such that the given physical address range is
-   * not mapped in the address space.
-   */
-  bool mm_unmap(paddr_t begin, paddr_t end, struct mpool *ppool)
+/**
+ * Updates the hypervisor table such that the given physical address range is
+ * not mapped in the address space.
+ */
+bool mm_unmap(paddr_t begin, paddr_t end, struct mpool *ppool)
  *)
 Definition mm_unmap (s : concrete_state) (begin end_ : paddr_t) (ppool : mpool)
   : (bool * concrete_state * mpool) :=
@@ -132,5 +132,3 @@ void mm_defrag(struct mpool *ppool)
 Definition mm_defrag (s : concrete_state) (ppool : mpool)
   : (concrete_state * mpool) :=
   (s, ppool). (* TODO *)
-
-(* TODO: deindent the C code in this file *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -43,24 +43,6 @@ Definition mm_vm_get_attrs
            (t : ptable_pointer)
            (begin end_ : ptable_addr_t) : bool * attributes :=
   (false, 0%N). (* TODO *)
-(*
-  /**
-  * Gets the mode of the give range of intermediate physical addresses if they
-  * are mapped with the same mode.
-  *
-  * Returns true if the range is mapped with the same mode and false otherwise.
-  */
-  bool mm_vm_get_mode(struct mm_ptable *t, ipaddr_t begin, ipaddr_t end,
-       int *mode)
- *)
-(* N.B. the comment above the function means "the entire range of addresses
-   has one consistent mode" and not "the range of addresses has the same
-   mode as is indicated by the pointer passed in". *)
-Definition mm_vm_get_mode
-           (s : concrete_state)
-           (t : ptable_pointer)
-           (begin end_ : ipaddr_t) : bool * mode_t :=
-  (false, 0%N). (* TODO *)
 
 (*
   /**
@@ -92,6 +74,25 @@ Definition mm_vm_defrag
            (s : concrete_state) (t : ptable_pointer) (ppool : mpool)
   : (bool * concrete_state * mpool) :=
   (false, s, ppool). (* TODO *)
+
+(*
+  /**
+  * Gets the mode of the give range of intermediate physical addresses if they
+  * are mapped with the same mode.
+  *
+  * Returns true if the range is mapped with the same mode and false otherwise.
+  */
+  bool mm_vm_get_mode(struct mm_ptable *t, ipaddr_t begin, ipaddr_t end,
+       int *mode)
+ *)
+(* N.B. the comment above the function means "the entire range of addresses
+   has one consistent mode" and not "the range of addresses has the same
+   mode as is indicated by the pointer passed in". *)
+Definition mm_vm_get_mode
+           (s : concrete_state)
+           (t : ptable_pointer)
+           (begin end_ : ipaddr_t) : bool * mode_t :=
+  (false, 0%N). (* TODO *)
 
 (*
   /**


### PR DESCRIPTION
On top of #13 

- Deindent the C code that's copied over on top of the functions
- Change definition order to match `mm.c`

Will plan to merge without review, since this involves no functional changes.