### PR TITLE
Transcribe mm_vm_get_attrs and helpers from mm.c

### DIFF
--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -254,7 +254,7 @@ Definition api_share_memory
               (* N.B. the case structure looks a little different here
                  because of functional/imperative differences -- each failure
                  case is handled as one big boolean *)
-              if (((orig_from_mode & MM_MODE_UNOWNED)%N)
+              if ((orig_from_mode & MM_MODE_UNOWNED)
                     && ((match share with
                          | HF_MEMORY_GIVE => false
                          | _ => true
@@ -263,14 +263,14 @@ Definition api_share_memory
                                     state to.(vm_root_ptable) begin end_ with
                             | (false, _) => false
                             | (true, orig_to_mode) =>
-                              (orig_to_mode & MM_MODE_UNOWNED)%N
+                              (orig_to_mode & MM_MODE_UNOWNED)
                             end)))%bool
               then goto_fail state local_page_pool (* first failure case *)
               else
                 (* we have to handle the else-if case separately, checking
                    MM_MODE_UNOWNED again *)
-                if (!(orig_from_mode & MM_MODE_UNOWNED)%N
-                     && (orig_from_mode & MM_MODE_SHARED)%N)%bool
+                if (!(orig_from_mode & MM_MODE_UNOWNED)
+                     && (orig_from_mode & MM_MODE_SHARED))%bool
                 then goto_fail state local_page_pool
                 else
                   (*

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -1,4 +1,5 @@
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
 
 (*** This file defines (the necessary parts of) the API provided by addr.h,
      which is assumed correct for now. In order to replace this assumption with
@@ -9,6 +10,8 @@ Axiom ipaddr_t : Type.
 
 Axiom paddr_t : Type.
 
+Axiom vaddr_t : Type.
+
 Axiom pa_addr : paddr_t -> uintpaddr_t.
 
 Axiom pa_difference : paddr_t -> paddr_t -> size_t.
@@ -17,7 +20,11 @@ Axiom ipa_addr : ipaddr_t -> uintpaddr_t.
 
 Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.
 
+Axiom va_from_pa : paddr_t -> vaddr_t.
+
 Axiom pa_from_ipa : ipaddr_t -> paddr_t.
+
+Axiom ptr_from_va : vaddr_t -> ptable_pointer.
 
 Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
 

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -31,3 +31,11 @@ Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.
 Axiom arch_mm_stage2_attrs_to_mode : attributes -> mode_t.
 
 Axiom arch_mm_stage1_attrs_to_mode : attributes -> mode_t.
+
+Axiom arch_mm_stage2_max_level : level.
+
+Axiom arch_mm_stage1_max_level : level.
+
+Axiom arch_mm_stage2_root_table_count : nat.
+
+Axiom arch_mm_stage1_root_table_count : nat.

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -5,8 +5,8 @@ Import ListNotations.
      in e.g. mm.h. These are left abstract because none of the proofs should
      depend on their exact values. ***)
 
-(* PAGE_SIZE is a natural number *)
-Axiom PAGE_SIZE : nat.
+(* page size parameters are natural numbers *)
+Axiom PAGE_SIZE PAGE_BITS PAGE_LEVEL_BITS : nat.
 
 (* PTEs per page -- natural number *)
 Axiom MM_PTE_PER_PAGE : nat.
@@ -22,3 +22,9 @@ Axiom MM_MODE_R MM_MODE_W MM_MODE_X MM_MODE_INVALID MM_MODE_UNOWNED
 Axiom mm_modes_distinct :
   NoDup [MM_MODE_R; MM_MODE_W; MM_MODE_X; MM_MODE_INVALID; MM_MODE_UNOWNED;
            MM_MODE_SHARED].
+
+(* mm flags are all natural numbers*)
+(* N.B. : In the same way as mm_mode flags, these are not binary numbers with
+   a single bit set but rather represent the index of the bit that would be set,
+   so that the single-bit-set format of the number is obvious by construction. *)
+Axiom MM_FLAG_STAGE1 : nat.

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -12,9 +12,14 @@ Definition mm_mode_get_flag (m : int) (flag : nat) : bool :=
 Notation "[ x | .. | y ]" :=
   (mm_mode_set_flag .. (mm_mode_set_flag 0 x) .. y)
     (at level 49, y at level 0, only parsing) : N_scope.
+Notation "x & y" :=
+  (N.land x y) (at level 49, y at level 0, only parsing) : N_scope.
 Notation "x & y " :=
   (mm_mode_get_flag x y)
-    (at level 49, y at level 0, only parsing) : N_scope.
+    (at level 49, y at level 0, only parsing) : bool_scope.
+Notation "x &~ y" := (N.land x (N.lnot y (N.size x))) (at level 199) : N_scope.
+Infix ">>" := N.shiftr (at level 199) : N_scope.
+Infix "<<" := N.shiftl (at level 199) : N_scope.
 
 Bind Scope N_scope with mode_t.
 Bind Scope N_scope with attributes.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -31,6 +31,8 @@ Class concrete_params :=
     hafnium_root_ptable : ptable_pointer;
   }.
 
+(* TODO: rename ptable_lookup to ptable_deref to remove confusion with page
+   table lookups *)
 Record concrete_state :=
   {
     (* representation of the state of page tables in memory *)
@@ -62,7 +64,7 @@ Definition haf_page_valid
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Local Definition owned (mode : mode_t) : Prop :=
-  (mode & MM_MODE_UNOWNED)%N = false.
+  (mode & MM_MODE_UNOWNED)%bool = false.
 
 Definition vm_page_owned (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists e : pte_t,


### PR DESCRIPTION
On top of #15 

- Change some notations to make & usable in a way that looks more like the code
- Encode a description of what it means to index into a `mm_page_table` struct (see the long explanatory comment in `MM/Datatypes.v`)
- Add some functions/constants to `Assumptions/Constants.v`, `Assumptions/Addr.v`, and `Assumptions/ArchMM/v` as needed by `mm_vm_get_attrs` and its dependencies within `mm.c`
- Transcribe `mm_vm_get_attrs` and its helpers; leave `mm_ptable_get_attrs_level` as a stub and transcribe the rest

The most important parts of this PR are the encoding of struct indexing in `MM/Datatypes.v` and the transcriptions in `MM/Implementation.v`.