### PR TITLE
Transcribe mm_vm_identity_map and mm_ptable_identity_update

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -39,3 +39,5 @@ Axiom arch_mm_stage1_max_level : level.
 Axiom arch_mm_stage2_root_table_count : nat.
 
 Axiom arch_mm_stage1_root_table_count : nat.
+
+Axiom arch_mm_mode_to_stage2_attrs : mode_t -> attributes.

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -41,3 +41,5 @@ Axiom arch_mm_stage2_root_table_count : nat.
 Axiom arch_mm_stage1_root_table_count : nat.
 
 Axiom arch_mm_mode_to_stage2_attrs : mode_t -> attributes.
+
+Axiom arch_mm_clear_pa : paddr_t -> paddr_t.

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -1,4 +1,5 @@
 Require Import Coq.Lists.List.
+Require Import Coq.NArith.BinNat.
 Import ListNotations.
 
 (*** This file lists the types and names of constants that we assume are defined
@@ -11,20 +12,33 @@ Axiom PAGE_SIZE PAGE_BITS PAGE_LEVEL_BITS : nat.
 (* PTEs per page -- natural number *)
 Axiom MM_PTE_PER_PAGE : nat.
 
-(* mm_mode flags are all natural numbers*)
-(* N.B. : mode flags are taken as *indices* in the binary number; this makes it
-   easier to state that they are all distinct and makes it true by construction
-   that they each affect only one bit of the overall mode. *)
-Axiom MM_MODE_R MM_MODE_W MM_MODE_X MM_MODE_INVALID MM_MODE_UNOWNED
-      MM_MODE_SHARED : nat.
+(* A lot of constants are MM_FLAG or MM_MODE and are single bits designed to be
+   or-ed with binary numbers to create flag or mode codes. Proofs should not
+   depend on where the bit is located (as long as it is distinct from the others
+   and within the number of bits in the flag/mode code), so we want to leave these
+   indices as assumptions instead of hardcoding their values. However, we still
+   want to be able to prove that they are in fact single-bit numbers.
+   Compromising between these constraints, we assume a natural number for each
+   flag/mode that represents the *index* of the set bit, and write a definition
+   that converts them to binary numbers. *)
+Axiom MM_MODE_R_index MM_MODE_W_index MM_MODE_X_index MM_MODE_INVALID_index
+      MM_MODE_UNOWNED_index MM_MODE_SHARED_index : nat.
+Axiom MM_FLAG_STAGE1_index MM_FLAG_COMMIT_index : nat.
 
-(* assume that all mode-flag indices are distinct from each other *)
+Definition index_to_N (i : nat) := N.shiftl 1 (N.of_nat i).
+
+Definition MM_MODE_R : N := index_to_N MM_MODE_R_index.
+Definition MM_MODE_W : N := index_to_N MM_MODE_W_index.
+Definition MM_MODE_X : N := index_to_N MM_MODE_X_index.
+Definition MM_MODE_INVALID : N := index_to_N MM_MODE_INVALID_index.
+Definition MM_MODE_UNOWNED : N := index_to_N MM_MODE_UNOWNED_index.
+Definition MM_MODE_SHARED : N := index_to_N MM_MODE_SHARED_index.
+Definition MM_FLAG_STAGE1 : N := index_to_N MM_FLAG_STAGE1_index.
+Definition MM_FLAG_COMMIT : N := index_to_N MM_FLAG_COMMIT_index.
+
+(* assume that all indices are distinct from each other *)
 Axiom mm_modes_distinct :
-  NoDup [MM_MODE_R; MM_MODE_W; MM_MODE_X; MM_MODE_INVALID; MM_MODE_UNOWNED;
-           MM_MODE_SHARED].
-
-(* mm flags are all natural numbers*)
-(* N.B. : In the same way as mm_mode flags, these are not binary numbers with
-   a single bit set but rather represent the index of the bit that would be set,
-   so that the single-bit-set format of the number is obvious by construction. *)
-Axiom MM_FLAG_STAGE1 : nat.
+  NoDup [MM_MODE_R_index; MM_MODE_W_index; MM_MODE_X_index; MM_MODE_INVALID_index;
+           MM_MODE_UNOWNED_index; MM_MODE_SHARED_index].
+Axiom mm_flags_distinct :
+  NoDup [MM_FLAG_STAGE1_index; MM_FLAG_COMMIT_index].

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -14,6 +14,12 @@ Require Import Hafnium.Concrete.MM.Datatypes.
 (*** This file transcribes necessary functions from mm.c, with the original C in
      comments alongside. ***)
 
+(* TODO: standardize the "SKIPPED" keyword as an indication that some C code is
+   not being transcribed *)
+(* TODO: make the begin-comment and end-comment parentheses on the same lines as
+   copied C code instead of the lines above and below so there's less gratuitious
+   use of space for the copied code. *)
+
 (* typedef uintvaddr_t ptable_addr_t; *)
 Definition ptable_addr_t : Type := uintvaddr_t.
 Bind Scope N_scope with ptable_addr_t.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -118,6 +118,25 @@ Definition mm_root_table_count (flags : int) : nat :=
 
 (*
 /**
+ * Updates the given table such that the given physical address range is mapped
+ * or not mapped into the address space with the architecture-agnostic mode
+ * provided.
+ */
+static bool mm_ptable_identity_update(struct mm_ptable *t, paddr_t pa_begin,
+				      paddr_t pa_end, uint64_t attrs, int flags,
+				      struct mpool *ppool)
+ *)
+Definition mm_ptable_identity_update
+           (s : concrete_state)
+           (t : ptable_pointer)
+           (pa_begin pa_end : paddr_t)
+           (attrs : attributes)
+           (flags : int)
+           (ppool : mpool) : bool * concrete_state * mpool :=
+  (false, s, ppool). (* TODO *)
+
+(*
+/**
  * Gets the attributes applied to the given range of stage-2 addresses at the
  * given level.
  *
@@ -348,7 +367,21 @@ Definition mm_vm_identity_map
            (end_ : paddr_t)
            (mode : mode_t)
            (ppool : mpool) : (bool * concrete_state * mpool) :=
-  (false, s, ppool).
+  (* int flags = 0; *)
+  let flags : int := 0 in
+
+  (* bool success = mm_ptable_identity_update(
+              t, begin, end, arch_mm_mode_to_stage2_attrs(mode), flags,
+              ppool); *)
+  let '(success, state, ppool) :=
+      mm_ptable_identity_update
+        s t begin end_ (arch_mm_mode_to_stage2_attrs mode) flags ppool in
+
+  (* N.B. since we're assuming ipa is NULL we can skip the if clause that sets
+     it if it's not null *)
+
+  (* return success *)
+  (success, state, ppool).
 
 (*
   /**

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -99,9 +99,9 @@ static uint8_t mm_max_level(int flags)
 Definition mm_max_level (flags : int) : nat :=
   (* return (flags & MM_FLAG_STAGE1) ? arch_mm_stage1_max_level()
                                      : arch_mm_stage2_max_level(); *)
-  if (flags & MM_FLAG_STAGE1)%bool
-  then arch_mm_stage1_max_level
-  else arch_mm_stage2_max_level.
+  if ((flags & MM_FLAG_STAGE1) =? 0)%N
+  then arch_mm_stage2_max_level
+  else arch_mm_stage1_max_level.
 
 (*
 /**
@@ -112,9 +112,9 @@ static uint8_t mm_root_table_count(int flags)
 Definition mm_root_table_count (flags : int) : nat :=
   (* return (flags & MM_FLAG_STAGE1) ? arch_mm_stage1_root_table_count()
                                      : arch_mm_stage2_root_table_count(); *)
-  if (flags & MM_FLAG_STAGE1)%bool
-  then arch_mm_stage1_root_table_count
-  else arch_mm_stage2_root_table_count.
+  if ((flags & MM_FLAG_STAGE1) =? 0)%N
+  then arch_mm_stage2_root_table_count
+  else arch_mm_stage1_root_table_count.
 
 (*
 /**

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -5,19 +5,9 @@ Require Import Hafnium.Concrete.Datatypes.
      the model more readable ***)
 
 (* nicer display of mm_mode operations *)
-Definition mm_mode_set_flag (m : int) (flag : nat) : int :=
-  N.setbit m (N.of_nat flag).
-Definition mm_mode_get_flag (m : int) (flag : nat) : bool :=
-  N.testbit m (N.of_nat flag).
-Notation "[ x | .. | y ]" :=
-  (mm_mode_set_flag .. (mm_mode_set_flag 0 x) .. y)
-    (at level 49, y at level 0, only parsing) : N_scope.
-Notation "x & y" :=
-  (N.land x y) (at level 49, y at level 0, only parsing) : N_scope.
-Notation "x & y " :=
-  (mm_mode_get_flag x y)
-    (at level 49, y at level 0, only parsing) : bool_scope.
 Notation "x &~ y" := (N.land x (N.lnot y (N.size x))) (at level 199) : N_scope.
+Infix "|||" := N.lor (at level 199) : N_scope.
+Infix "&" := N.land (at level 199) : N_scope.
 Infix ">>" := N.shiftr (at level 199) : N_scope.
 Infix "<<" := N.shiftl (at level 199) : N_scope.
 

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -62,7 +62,7 @@ Definition haf_page_valid
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Local Definition owned (mode : mode_t) : Prop :=
-  (mode & MM_MODE_UNOWNED)%bool = false.
+  (mode & MM_MODE_UNOWNED)%N <> 0.
 
 Definition vm_page_owned (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists e : pte_t,


### PR DESCRIPTION
Besides the two code transcriptions, I've also changed some things about the way the `MM_MODE` and `MM_FLAG` bit-setting and bit-testing is done to make it more clear. These changes can be viewed independently as the single commit `f323dc2`.