### PR TITLE
Transcribe 5 functions from mm.c

### DIFF
--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -212,7 +212,7 @@ Definition api_share_memory
                 if (orig_from_mode & MM_MODE_INVALID) {
                         goto fail;
                 } *)
-            if (!((orig_from_mode & MM_MODE_INVALID) =? 0)%N)%bool
+            if (orig_from_mode & MM_MODE_INVALID != 0)%bool
             then goto_fail state local_page_pool
             else
               (* /*
@@ -234,7 +234,7 @@ Definition api_share_memory
                  because of functional/imperative differences -- each failure
                  case is handled as one big boolean *)
               if (
-                  (!(orig_from_mode & MM_MODE_UNOWNED) =? 0)%N
+                  (orig_from_mode & MM_MODE_UNOWNED != 0)
                     && ((match share with
                          | HF_MEMORY_GIVE => false
                          | _ => true
@@ -243,14 +243,14 @@ Definition api_share_memory
                                     state to.(vm_ptable) begin end_ with
                             | (false, _) => false
                             | (true, orig_to_mode) =>
-                              !((orig_to_mode & MM_MODE_UNOWNED) =? 0)%N
+                              (orig_to_mode & MM_MODE_UNOWNED != 0)
                             end)))%bool
               then goto_fail state local_page_pool (* first failure case *)
               else
                 (* we have to handle the else-if case separately, checking
                    MM_MODE_UNOWNED again *)
                 if (((orig_from_mode & MM_MODE_UNOWNED) =? 0)%N
-                     && !((orig_from_mode & MM_MODE_SHARED) =? 0)%N)%bool
+                     && (orig_from_mode & MM_MODE_SHARED != 0))%bool
                 then goto_fail state local_page_pool
                 else
 

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -16,6 +16,9 @@ Axiom arch_mm_absent_pte : level -> pte_t.
 
 Axiom arch_mm_block_pte : level -> paddr_t -> attributes -> pte_t.
 
+(* N.B. we take in a ptable_pointer instead of a paddr_t here *)
+Axiom arch_mm_table_pte : level -> ptable_pointer -> pte_t.
+
 Axiom arch_mm_pte_is_present : pte_t -> level -> bool.
 
 Axiom arch_mm_pte_is_valid : pte_t -> level -> bool.
@@ -24,6 +27,7 @@ Axiom arch_mm_pte_is_block : pte_t -> level -> bool.
 
 Axiom arch_mm_pte_is_table : pte_t -> level -> bool.
 
+(* TODO: should this return ptable_pointer? *)
 Axiom arch_mm_table_from_pte : pte_t -> level -> paddr_t.
 
 Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.
@@ -45,3 +49,5 @@ Axiom arch_mm_mode_to_stage2_attrs : mode_t -> attributes.
 Axiom arch_mm_clear_pa : paddr_t -> paddr_t.
 
 Axiom arch_mm_is_block_allowed : level -> bool.
+
+Axiom arch_mm_block_from_pte : pte_t -> level -> paddr_t.

--- a/coq-verification/src/Concrete/Assumptions/Datatypes.v
+++ b/coq-verification/src/Concrete/Assumptions/Datatypes.v
@@ -4,3 +4,7 @@
 
 (* pointers to page tables *)
 Axiom ptable_pointer : Type.
+
+(* equality between pointers is decidable *)
+Axiom ptable_pointer_eq_dec :
+  forall ptr1 ptr2 : ptable_pointer, {ptr1 = ptr2} + {ptr1 <> ptr2}.

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -20,4 +20,6 @@ Axiom mpool_alloc : mpool -> option (mpool * ptable_pointer).
 (* Return the new state of the mpool *)
 Axiom mpool_free : mpool -> ptable_pointer -> mpool.
 
-(* TODO: add axioms for correctness properties, as needed *)
+(* allocate contiguous locations *)
+Axiom mpool_alloc_contiguous :
+  mpool -> size_t -> size_t -> option (mpool * ptable_pointer).

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -25,6 +25,8 @@ Axiom offset : uintpaddr_t -> nat.
    ptable_pointer out of it *)
 Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
 
+(* TODO : this is not true by construction of the current type -- either type
+   needs to have a tuple or this needs to in preconditions of lemmas. *)
 Axiom page_table_size :
   forall ptable : mm_page_table, length ptable.(entries) = MM_PTE_PER_PAGE.
 

--- a/coq-verification/src/Concrete/MM/Datatypes.v
+++ b/coq-verification/src/Concrete/MM/Datatypes.v
@@ -1,5 +1,6 @@
 Require Import Coq.Lists.List.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.List.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 
 (*** This file transcribes some datatypes found in mm.h, with original C in
@@ -19,6 +20,11 @@ struct mm_ptable {
 };
  *)
 Record mm_ptable := { root : paddr_t }.
+
+(* Shortcut definition for replacing the PTE at a given index *)
+Definition mm_page_table_replace_entry
+           (t : mm_page_table) (pte : pte_t) (index : nat) : mm_page_table :=
+  {| entries := set_nth t.(entries) pte index |}.
 
 (*
   Some of the code in mm.c looks like this:

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -17,6 +17,7 @@ Bind Scope N_scope with uintpaddr_t.
 Bind Scope N_scope with uintvaddr_t.
 
 Notation "! x" := (negb x) (at level 200) : bool_scope.
+Notation "x != y" := (negb (N.eqb x y)) (at level 199) : bool_scope.
 
 Coercion N.of_nat : nat >-> N. (* change nat to N automatically *)
 Set Printing Coercions. (* when printing, show N.of_nat explicitly *)

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -38,6 +38,18 @@ Record concrete_state :=
     api_page_pool : mpool;
   }.
 
+Definition reassign_pointer
+           (s : concrete_state) (ptr : ptable_pointer) (t : mm_page_table)
+  : concrete_state :=
+  {|
+    ptable_deref :=
+      (fun ptr' =>
+         if ptable_pointer_eq_dec ptr ptr'
+         then t
+         else s.(ptable_deref) ptr);
+    api_page_pool := s.(api_page_pool);
+  |}.
+
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
   (* Possible constraints:
         - Block PTEs have the valid bit set


### PR DESCRIPTION
This PR transcribes several functions from `mm.c`: `mm_free_page_pte`, `mm_replace_entry`, `mm_populate_table_pte`, `mm_alloc_page_tables`, and `mm_page_table_is_empty`.

In the process, it was necessary to decide how to handle the fact that, in the C code, page tables are edited under pointers, whereas in functional programming this concept doesn't exist. Instead, we have to construct a new table, return it, and then update any references to the old table. It was necessary to use this technique in `mm_replace_entry` and also go back to `mm_map_level` and fix an occurrence of editing-under-pointer that I had missed. Finally, I edited `mm_map_level` to update the global state with the new table.

I also did a bit of housekeeping in making a more readable notation for checking whether flags are nonzero.