### PR TITLE
Transcribe mm_vm_defrag and all its helpers

### DIFF
--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -309,7 +309,7 @@ Definition api_share_memory
                                                to_mode
                                                local_page_pool with
                       | (false, state, local_page_pool) =>
-                        let '(_, state, local_page_pool) :=
+                        let '(state, local_page_pool) :=
                             mm_vm_defrag state from.(vm_ptable) local_page_pool in
                         goto_fail_return_to_sender
                           state

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -26,7 +26,7 @@ Axiom va_from_pa : paddr_t -> vaddr_t.
 
 Axiom pa_from_ipa : ipaddr_t -> paddr_t.
 
-Axiom ptr_from_va : vaddr_t -> ptable_pointer.
+Axiom ptr_from_va : vaddr_t -> list ptable_pointer.
 
 Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
 

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -51,3 +51,5 @@ Axiom arch_mm_clear_pa : paddr_t -> paddr_t.
 Axiom arch_mm_is_block_allowed : level -> bool.
 
 Axiom arch_mm_block_from_pte : pte_t -> level -> paddr_t.
+
+Axiom arch_mm_combine_table_entry_attrs : attributes -> attributes -> attributes.

--- a/coq-verification/src/Concrete/Assumptions/Datatypes.v
+++ b/coq-verification/src/Concrete/Assumptions/Datatypes.v
@@ -8,3 +8,6 @@ Axiom ptable_pointer : Type.
 (* equality between pointers is decidable *)
 Axiom ptable_pointer_eq_dec :
   forall ptr1 ptr2 : ptable_pointer, {ptr1 = ptr2} + {ptr1 <> ptr2}.
+
+(* assume NULL exists *)
+Axiom null_pointer : ptable_pointer.

--- a/coq-verification/src/Concrete/MM/Datatypes.v
+++ b/coq-verification/src/Concrete/MM/Datatypes.v
@@ -26,40 +26,9 @@ Definition mm_page_table_replace_entry
            (t : mm_page_table) (pte : pte_t) (index : nat) : mm_page_table :=
   {| entries := set_nth t.(entries) pte index |}.
 
-(*
-  Some of the code in mm.c looks like this:
-
-       struct mm_page_table *table;
-       table = &mm_page_table_from_pa(t->root)[mm_index(begin, root_level)];
-
-  The code directly indexes into an mm_page_table struct. Since #pragma is set,
-  the struct won't be padded, so indexing returns a pointer to the given
-  location in the [entries] list, and then this is treated as an mm_page_table
-  pointer  Since the [entries] list is a fixed size, the new table will contain
-  whatever locations in memory happen to exist after [entries] finishes. This
-  unsafe access is protected against in the code by manual checks that the range
-  of locations being accessed doesn't go past the end of the original table.
-
-  For verification purposes, I have encoded this functionality as a function
-  that takes an index and a page table and returns a page table with opaque
-  entries after the given index (meaning proofs don't have any information
-  about these entries and can't rely on any of their properties). This should
-  capture the concept that although those entries are theoretically part of the
-  page table, their contents are completely undefined.
-
-  Depending on what kind of code semantics are eventually used for verification,
-  the C code might need to change to do something less magical.
- *)
-
 (* opaque type of PTEs returned by an out-of-bounds access *)
 Axiom out_of_bounds_access_pte : pte_t.
 
-Definition index_into_mm_page_table_struct (table : mm_page_table) (i : nat)
-  : mm_page_table :=
-  {| entries := skipn i table.(entries) ++ repeat out_of_bounds_access_pte i |}.
-
-Notation "x {{ y }}" := (index_into_mm_page_table_struct x y) (at level 199, only parsing).
-
-(* separate notation for getting the PTE at an index *)
+(* special notation for getting the PTE at a particular index *)
 Notation "x [[ y ]]" :=
   (nth_default out_of_bounds_access_pte x.(entries) y) (at level 199, only parsing).

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -1175,6 +1175,9 @@ Definition mm_vm_defrag
            (s : concrete_state) (t : mm_ptable) (ppool : mpool)
   : (concrete_state * mpool) :=
   (* mm_ptable_defrag(t, 0, ppool); *)
+  (* N.B. "0" indicates all-false flags -- the only one read by mm_ptable_defrag
+     and its helpers is MM_FLAG_STAGE1, so this indicates that t is a stage-2
+     page table *)
   mm_ptable_defrag s t 0 ppool.
 
 (*

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -952,13 +952,42 @@ Definition mm_vm_identity_map
 
 (*
 /**
+ * Defragments the given PTE by recursively replacing any tables with blocks or
+ * absent entries where possible.
+ */
+static pte_t mm_ptable_defrag_entry(pte_t entry, uint8_t level,
+				    struct mpool *ppool) *)
+Definition mm_ptable_defrag_entry
+           (s : concrete_state)
+           (entry : pte_t)
+           (level : nat)
+           (ppool : mpool) : pte_t * concrete_state * mpool :=
+  (entry, s, ppool). (* TODO *)
+
+(*
+/**
+ * Defragments the given page table by converting page table references to
+ * blocks whenever possible.
+ */
+static void mm_ptable_defrag(struct mm_ptable *t, int flags,
+			     struct mpool *ppool) *)
+Definition mm_ptable_defrag
+           (s : concrete_state)
+           (t : mm_ptable)
+           (flags : int)
+           (ppool : mpool) : concrete_state * mpool :=
+  (s, ppool). (* TODO *)
+
+(*
+/**
  * Defragments the VM page table.
  */
 void mm_vm_defrag(struct mm_ptable *t, struct mpool *ppool) *)
 Definition mm_vm_defrag
            (s : concrete_state) (t : mm_ptable) (ppool : mpool)
-  : (bool * concrete_state * mpool) :=
-  (false, s, ppool). (* TODO *)
+  : (concrete_state * mpool) :=
+  (* mm_ptable_defrag(t, 0, ppool); *)
+  mm_ptable_defrag s t 0 ppool.
 
 (*
 /**


### PR DESCRIPTION
This includes fixing a confusion I had about the return type of `mm_page_table_from_pa` after chatting with Andrew for clarification. We no longer need the special definition for indexing into structs because that wasn't actually what was going on; rather, there was actually a list of structs to index into, because the pointer returned by `mm_page_table_from_pa` sometimes represents the head of a list.

Best reviewed commit-by-commit to isolate the changes described above from the garden-variety transcriptions.