### PR TITLE
Minor modifications to mpool interface

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -15,11 +15,17 @@ Axiom mpool_fini : mpool -> option mpool.
 
 (* If there's a location available, return the new state and the pointer,
    otherwise return [None] *)
+(* N.B. although the comment above [mpool_alloc] says it allocates an *entry*,
+   the pointer it returns is immediately cast to an [mm_page_table], so it seems
+   like it actually allocates full pages at a time (assuming a table takes one
+   page of memory). Similarly, [mpool_free] frees one table-sized (= page-sized)
+   block of memory at a time. *)
 Axiom mpool_alloc : mpool -> option (mpool * ptable_pointer).
 
 (* Return the new state of the mpool *)
 Axiom mpool_free : mpool -> ptable_pointer -> mpool.
 
-(* allocate contiguous locations *)
+(* allocate contiguous locations -- the second argument is the number of tables
+   to allocate *)
 Axiom mpool_alloc_contiguous :
-  mpool -> size_t -> size_t -> option (mpool * ptable_pointer).
+  mpool -> size_t -> size_t -> option (mpool * list ptable_pointer).


### PR DESCRIPTION
I've taken a closer look at `mpool.c` during an email exchange with @hkim15 and realized that my transcription of the file in `Assumptions` is a bit behind my current understanding. I've added some clarifying comments and changed `mpool_alloc_contiguous` to return a list, since this function in fact allocates multiple *tables*, not just multiple *entries*.

I'll request a review on this even though it's minor, just to follow up with the email conversation.