### PR TITLE
Transcribe the last functions from mm.c

### DIFF
--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -25,6 +25,7 @@ static bool api_clear_memory(paddr_t begin, paddr_t end, struct mpool *ppool) *)
 (* N.B. current mm_identity_map transcription returns false for a null pointer
    and true otherwise *)
 Definition api_clear_memory
+           {cp : concrete_params}
            (state : concrete_state)
            (begin : paddr_t)
            (end_ : paddr_t)

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -44,6 +44,8 @@ Axiom arch_mm_stage2_root_table_count : nat.
 
 Axiom arch_mm_stage1_root_table_count : nat.
 
+Axiom arch_mm_mode_to_stage1_attrs : mode_t -> attributes.
+
 Axiom arch_mm_mode_to_stage2_attrs : mode_t -> attributes.
 
 Axiom arch_mm_clear_pa : paddr_t -> paddr_t.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -1266,6 +1266,7 @@ Definition mm_unmap {cp : concrete_params} (s : concrete_state)
  * Defragments the hypervisor page table.
  */
 void mm_defrag(struct mpool *ppool) *)
-Definition mm_defrag (s : concrete_state) (ppool : mpool)
+Definition mm_defrag {cp : concrete_params} (s : concrete_state) (ppool : mpool)
   : (concrete_state * mpool) :=
-  (s, ppool). (* TODO *)
+  (* mm_ptable_defrag(stage1_locked.ptable, MM_FLAG_STAGE1, ppool); *)
+  mm_ptable_defrag s hafnium_ptable MM_FLAG_STAGE1 ppool.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -908,7 +908,7 @@ Definition mm_vm_get_attrs
                match mm_ptable_get_attrs_level
                        s.(ptable_deref) table begin end_ max_level got_attrs attrs with
                | (false, attrs) =>
-                 (* set get_attrs to false and break to return false *)
+                 (* set got_attrs to false and break to return false *)
                  (begin, table_index, false, attrs, break)
                | (true, attrs) =>
                  let got_attrs := true in

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -1196,7 +1196,18 @@ Definition mm_vm_get_mode
            (s : concrete_state)
            (t : mm_ptable)
            (begin end_ : ipaddr_t) : bool * mode_t :=
-  (false, 0%N). (* TODO *)
+  (* ret = mm_vm_get_attrs(t, ipa_addr(begin), ipa_addr(end), &attrs); *)
+  match mm_vm_get_attrs s t (ipa_addr begin) (ipa_addr end_) with
+  | (false, _) => (false, 0%N)
+  | (true, attrs) =>
+
+    (* if (ret) {
+                *mode = arch_mm_stage2_attrs_to_mode(attrs);
+       }
+       return ret; *)
+    let mode := arch_mm_stage2_attrs_to_mode attrs in
+    (true, mode)
+  end.
 
 (*
 /**

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -1246,9 +1246,20 @@ Definition mm_identity_map
  * not mapped in the address space.
  */
 bool mm_unmap(paddr_t begin, paddr_t end, struct mpool *ppool) *)
-Definition mm_unmap (s : concrete_state) (begin end_ : paddr_t) (ppool : mpool)
+Definition mm_unmap {cp : concrete_params} (s : concrete_state)
+           (begin end_ : paddr_t) (ppool : mpool)
   : (bool * concrete_state * mpool) :=
-  (false, s, ppool). (* TODO *)
+  (* return mm_ptable_identity_update(
+             stage1_locked.ptable, begin, end,
+             arch_mm_mode_to_stage1_attrs(MM_MODE_UNOWNED | MM_MODE_INVALID |
+                                          MM_MODE_SHARED),
+             MM_FLAG_STAGE1 | MM_FLAG_UNMAP, ppool); *)
+  mm_ptable_identity_update
+    s hafnium_ptable begin end_
+    (arch_mm_mode_to_stage1_attrs
+       (MM_MODE_UNOWNED ||| MM_MODE_INVALID ||| MM_MODE_SHARED))
+    (MM_FLAG_STAGE1 ||| MM_FLAG_UNMAP)%N
+    ppool.
 
 (*
 /**

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -1218,13 +1218,27 @@ Definition mm_vm_get_mode
 void *mm_identity_map(paddr_t begin, paddr_t end, int mode, struct mpool *ppool) *)
 (* N.B. the original code returns a [void *] that is NULL if the operation
    failed; we will return a boolean instead, since we don't currently ever do
-   anything with the pointer except check if it's NULL. *)
+   anything with the pointer except check if it's NULL. Naturally, [false]
+   represents NULL. *)
 Definition mm_identity_map
+           {cp : concrete_params}
            (s : concrete_state)
            (begin end_ : paddr_t)
            (mode : mode_t)
            (ppool : mpool) : (bool * concrete_state * mpool) :=
-  (false, s, ppool). (* TODO *)
+
+  (* if (mm_ptable_identity_update(stage1_locked.ptable, begin, end,
+                                   arch_mm_mode_to_stage1_attrs(mode),
+                                   MM_FLAG_STAGE1, ppool)) {
+             return ptr_from_va(va_from_pa(begin));
+     }
+     return NULL; *)
+  match mm_ptable_identity_update s hafnium_ptable begin end_
+                                  (arch_mm_mode_to_stage1_attrs mode)
+                                  MM_FLAG_STAGE1 ppool with
+  | (true, s, ppool) => (true, s, ppool)
+  | (false, s, ppool) => (false, s, ppool)
+  end.
 
 (*
 /**

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -28,8 +28,11 @@ Definition vm_root_ptable (v : vm) : ptable_pointer :=
 Class concrete_params :=
   {
     vms : list vm;
-    hafnium_root_ptable : ptable_pointer;
+    hafnium_ptable : mm_ptable;
   }.
+
+Definition hafnium_root_ptable {cp : concrete_params} : ptable_pointer :=
+  ptable_pointer_from_address hafnium_ptable.(root).
 
 Record concrete_state :=
   {


### PR DESCRIPTION
This PR transcribes `mm_vm_get_mode`, `mm_identity_map`, `mm_unmap`, and `mm_defrag`. All were pretty easy to transcribe since they're mostly wrappers for already-transcribed functions.

There's more code in `mm.c`, mostly for initialization and tear-down, but that can be transcribed later when we add initialization and teardown to the API.