### PR TITLE
Lay groundwork for proofs

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -1,6 +1,7 @@
 -R src/ Hafnium
 src/AbstractModel.v
 src/Concrete/Datatypes.v
+src/Concrete/Model.v
 src/Concrete/Notations.v
 src/Concrete/State.v
 src/Util/List.v
@@ -15,3 +16,4 @@ src/Concrete/Assumptions/PageTables.v
 src/Concrete/MM/Datatypes.v
 src/Concrete/MM/Implementation.v
 src/Concrete/Api/Implementation.v
+src/Concrete/Api/Proofs.v

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -41,6 +41,6 @@ Lemma api_share_memory_represents
       vid addr size share current :
   represents abst conc ->
   let conc' := snd (api_share_memory conc vid addr size share current) in
-  exists abst', represents abst' conc.
+  exists abst', represents abst' conc'.
 Proof.
 Admitted. (* TODO *)

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -1,0 +1,46 @@
+Require Import Coq.Arith.PeanoNat.
+Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.State.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Api.Implementation.
+
+Lemma api_clear_memory_valid
+      {cp : concrete_params} (conc : concrete_state) begin end_ ppool :
+  is_valid conc ->
+  let conc' := snd (fst (api_clear_memory conc begin end_ ppool)) in
+  is_valid conc'.
+Proof.
+  tauto. (* N.B. this proof is trivial because is_valid isn't yet filled in *)
+Qed.
+
+Lemma api_clear_memory_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (abst : abstract_state) (conc : concrete_state)
+      begin end_ ppool :
+  represents abst conc ->
+  let conc' := snd (fst (api_clear_memory conc begin end_ ppool)) in
+  exists abst', represents abst' conc'.
+Proof.
+Admitted. (* TODO *)
+
+Lemma api_share_memory_valid
+      {cp : concrete_params} (conc : concrete_state)
+      vid addr size share current :
+  is_valid conc ->
+  let conc' := snd (api_share_memory conc vid addr size share current) in
+  is_valid conc'.
+Proof.
+  tauto. (* N.B. this proof is trivial because is_valid isn't yet filled in *)
+Qed.
+
+Lemma api_share_memory_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (abst : abstract_state) (conc : concrete_state)
+      vid addr size share current :
+  represents abst conc ->
+  let conc' := snd (api_share_memory conc vid addr size share current) in
+  exists abst', represents abst' conc.
+Proof.
+Admitted. (* TODO *)

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -30,4 +30,5 @@ Axiom ptr_from_va : vaddr_t -> list ptable_pointer.
 
 Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
 
-(* TODO: add axioms for correctness properties, as needed *)
+(* equality of the paddr_t type is decidable *)
+Axiom paddr_t_eq_dec : forall (a1 a2 : paddr_t), {a1 = a2} + {a1 <> a2}.

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -1,10 +1,13 @@
 Require Import Coq.Lists.List.
+Require Import Coq.Arith.PeanoNat.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.Tactics.
+Require Import Hafnium.Concrete.Api.Implementation.
+Require Import Hafnium.Concrete.Api.Proofs.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
-Require Import Hafnium.Concrete.Api.Implementation.
 
 (*** This file gives the definition of execution in the concrete model and
      includes the highest-level correctness proof, stating that the execution
@@ -15,20 +18,18 @@ Inductive api_call : Type :=
 | share_memory : nat -> ipaddr_t -> size_t -> hf_share -> vm -> api_call
 .
 
-Fixpoint execute_trace
-         {cp : concrete_params}
-         (start_state : concrete_state)
-         (trace : list api_call) : concrete_state :=
+Definition execute_trace
+           {cp : concrete_params}
+           (start_state : concrete_state)
+           (trace : list api_call) : concrete_state :=
   fold_right (fun next_call state =>
                 match next_call with
                 | clear_memory begin end_ ppool =>
-                  let '(_, state', _) :=
-                      api_clear_memory state begin end_ ppool in
-                  state'
+                  let ret := api_clear_memory state begin end_ ppool in
+                  snd (fst ret)
                 | share_memory vid addr size share current =>
-                  let '(_, state') :=
-                      api_share_memory state vid addr size share current in
-                  state'
+                  let ret := api_share_memory state vid addr size share current in
+                  snd ret
                 end)
              start_state trace.
 
@@ -40,13 +41,52 @@ Definition obeys_invariants
   exists abst : abstract_state,
     represents abst conc /\ AbstractModel.obeys_invariants abst.
 
+(* because [represents] includes [AbstractModel.is_valid], and we've proved all
+   valid abstract states obey the invariants, it's sufficient to just prove
+   [represents] *)
+Lemma represents_obeys_invariants
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (conc : concrete_state) :
+  (exists abst, represents abst conc) ->
+  obeys_invariants conc.
+Proof.
+  cbv [represents obeys_invariants]; basics.
+  eexists; basics; try solver; [ ].
+  apply (valid_obeys_invariants
+           (addr_eq_dec:=paddr_t_eq_dec) (vm_id_eq_dec:=Nat.eq_dec)).
+  eauto.
+Qed.
+
+Lemma execution_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (start_state : concrete_state) (trace : list api_call) :
+  (exists abst, represents abst start_state) ->
+  exists abst, represents abst (execute_trace start_state trace).
+Proof.
+  cbv [execute_trace]; intros; induction trace; [ basics; solver | ].
+  destruct IHtrace as [abst IHtrace]. basics.
+  cbn [fold_right]. break_match.
+  { (* case : api_clear_memory *)
+    apply api_clear_memory_represents with (abst0:=abst).
+    eapply IHtrace. }
+  { (* case : api_share_memory *)
+    apply api_share_memory_represents with (abst0:=abst).
+    eapply IHtrace. }
+Qed.
+
 (*** Highest-level correctness theorem: any execution of api calls will preserve
      the invariants; that is, if you obey the invariants at the start, no
      sequence of api calls can make you stop obeying them. ***)
-Theorem execution_preserves_invariants :
-  forall {ap : abstract_state_parameters} {cp : concrete_params}
-         (start_state : concrete_state) (trace : list api_call),
+Theorem execution_preserves_invariants
+        {ap : abstract_state_parameters} {cp : concrete_params} :
+  forall (trace : list api_call) (start_state : concrete_state),
     obeys_invariants start_state ->
     obeys_invariants (execute_trace start_state trace).
 Proof.
-Admitted. (* TODO *)
+  intros; apply represents_obeys_invariants, execution_represents.
+  cbv [obeys_invariants] in *. basics; solver.
+Qed.
+
+(* Uncomment the below to see all assumptions that the top-level correctness
+   theorem depends on. *)
+(* Print Assumptions execution_preserves_invariants. *)

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -1,0 +1,52 @@
+Require Import Coq.Lists.List.
+Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.State.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Api.Implementation.
+
+(*** This file gives the definition of execution in the concrete model and
+     includes the highest-level correctness proof, stating that the execution
+     rules of the concrete model obey the system invariants. ***)
+
+Inductive api_call : Type :=
+| clear_memory : paddr_t -> paddr_t -> mpool -> api_call
+| share_memory : nat -> ipaddr_t -> size_t -> hf_share -> vm -> api_call
+.
+
+Fixpoint execute_trace
+         {cp : concrete_params}
+         (start_state : concrete_state)
+         (trace : list api_call) : concrete_state :=
+  fold_right (fun next_call state =>
+                match next_call with
+                | clear_memory begin end_ ppool =>
+                  let '(_, state', _) :=
+                      api_clear_memory state begin end_ ppool in
+                  state'
+                | share_memory vid addr size share current =>
+                  let '(_, state') :=
+                      api_share_memory state vid addr size share current in
+                  state'
+                end)
+             start_state trace.
+
+(* A concrete state obeys the invariants if it's represented by an abstract
+   state that obeys them. *)
+Definition obeys_invariants
+           {ap : abstract_state_parameters} {cp : concrete_params}
+           (conc : concrete_state) : Prop :=
+  exists abst : abstract_state,
+    represents abst conc /\ AbstractModel.obeys_invariants abst.
+
+(*** Highest-level correctness theorem: any execution of api calls will preserve
+     the invariants; that is, if you obey the invariants at the start, no
+     sequence of api calls can make you stop obeying them. ***)
+Theorem execution_preserves_invariants :
+  forall {ap : abstract_state_parameters} {cp : concrete_params}
+         (start_state : concrete_state) (trace : list api_call),
+    obeys_invariants start_state ->
+    obeys_invariants (execute_trace start_state trace).
+Proof.
+Admitted. (* TODO *)

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -92,10 +92,13 @@ Definition haf_page_owned
 Arguments owned_by {_} {_} _.
 Arguments accessible_by {_} {_} _.
 Definition represents
+           {ap : abstract_state_parameters}
            {cp : concrete_params}
            (abst : @abstract_state paddr_t nat)
            (conc : concrete_state) : Prop :=
   is_valid conc
+  /\ AbstractModel.is_valid
+       (addr_eq_dec:=paddr_t_eq_dec) (vm_id_eq_dec:=Nat.eq_dec) abst
   /\ (forall (vid : nat) (a : paddr_t),
       In (inl vid) (abst.(accessible_by) a) <->
          (exists v : vm,
@@ -115,8 +118,3 @@ Definition abstract_state_equiv
   (forall a, s1.(owned_by) a = s2.(owned_by) a)
   /\ (forall e a,
          In e (s1.(accessible_by) a) <-> In e (s2.(accessible_by) a)).
-
-(* for every API function, we need to prove that if the concrete state (is
-   itself valid and) represents a valid abstract state before the call, then
-   the concrete state after the call (is also valid and) represents a valid
-   abstract state *)


### PR DESCRIPTION
This PR is pretty important; it sets up the structure from which all the future proofs will be build. Having transcribed everything I need (for now) from mm.c, I now need to actually prove that the code I transcribed has some relationship to the abstract model of the system, and obeys the high-level system invariants. This PR does that in three main steps:

1) Adds stubs in `Concrete/Api/Proofs.v` for correctness proofs of functions in `Concrete/Api/Implementation.v`, where the top-level API functions of the concrete model live.
2) Introduces a description (in `Concrete/Model.v`) of how to use the API to change the concrete state. In particular, you can take a starting concrete state and then run any sequence of API calls on it (but you can't change the state other than making the API calls).
3) Proves that, if the stubs in `Concrete/Api/Proofs.v` are true, then the concrete model obeys the system invariants from `AbstractModel.v`. This proof (`execution_preserves_invariants`) constitutes the highest-level correctness theorem.