### PR TITLE
Revisiting some old TODOs

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -27,7 +27,6 @@ Axiom arch_mm_pte_is_block : pte_t -> level -> bool.
 
 Axiom arch_mm_pte_is_table : pte_t -> level -> bool.
 
-(* TODO: should this return ptable_pointer? *)
 Axiom arch_mm_table_from_pte : pte_t -> level -> paddr_t.
 
 Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.

--- a/coq-verification/src/Concrete/Assumptions/Datatypes.v
+++ b/coq-verification/src/Concrete/Assumptions/Datatypes.v
@@ -1,3 +1,5 @@
+Require Import Hafnium.Util.List.
+
 (*** This file is for datatypes that are left abstract so as to avoid making any
      assumptions about their content. It may be necessary to instantiate these
      types later. ***)
@@ -11,3 +13,7 @@ Axiom ptable_pointer_eq_dec :
 
 (* assume NULL exists *)
 Axiom null_pointer : ptable_pointer.
+
+(* out-of-bounds accesses to lists of ptable_pointers return null_pointer *)
+Global Instance ptable_pointer_oobe : OutOfBoundsElement ptable_pointer :=
+  {| oob_value := null_pointer |}.

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -25,11 +25,6 @@ Axiom offset : uintpaddr_t -> nat.
    ptable_pointer out of it *)
 Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
 
-(* TODO : this is not true by construction of the current type -- either type
-   needs to have a tuple or this needs to in preconditions of lemmas. *)
-Axiom page_table_size :
-  forall ptable : mm_page_table, length ptable.(entries) = MM_PTE_PER_PAGE.
-
 Definition get_entry (ptable : mm_page_table) (i : nat) : option pte_t :=
   nth_error ptable.(entries) i.
 

--- a/coq-verification/src/Concrete/MM/Datatypes.v
+++ b/coq-verification/src/Concrete/MM/Datatypes.v
@@ -29,6 +29,6 @@ Definition mm_page_table_replace_entry
 (* opaque type of PTEs returned by an out-of-bounds access *)
 Axiom out_of_bounds_access_pte : pte_t.
 
-(* special notation for getting the PTE at a particular index *)
-Notation "x [[ y ]]" :=
-  (nth_default out_of_bounds_access_pte x.(entries) y) (at level 199, only parsing).
+(* out-of-bounds accesses to lists of PTEs return out_of_bounds_access_pte *)
+Global Instance ptable_pointer_oobe : OutOfBoundsElement pte_t :=
+  {| oob_value := out_of_bounds_access_pte |}.

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -1,5 +1,6 @@
 Require Import Coq.NArith.BinNat.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.List.
 
 (*** This file is mostly boilerplate to coerce Coq's notation system into making
      the model more readable ***)
@@ -21,3 +22,6 @@ Notation "x != y" := (negb (N.eqb x y)) (at level 199) : bool_scope.
 
 Coercion N.of_nat : nat >-> N. (* change nat to N automatically *)
 Set Printing Coercions. (* when printing, show N.of_nat explicitly *)
+
+Notation "x [[ y ]]" :=
+  (nth_default_oobe x y) (at level 199, only parsing).

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -274,6 +274,15 @@ Section ListQualifiers.
 
 End ListQualifiers.
 
+(* Define a notation for indexing into lists. Coq requires a default element to
+   be passed in case the index is out of bounds; in order not to have to repeat
+   this element everywhere, we create a class and will later globally instantiate
+   it for certain types. *)
+Class OutOfBoundsElement T := { oob_value : T }.
+Definition nth_default_oobe
+           {T} {oobe : OutOfBoundsElement T} (ls : list T) (i : nat) : T :=
+  nth_default oob_value ls i.
+
 (* populate the list_quals hint database *)
 Hint Resolve FOP_nil FOP_cons Forall_nil Forall_forall
   : list_quals.


### PR DESCRIPTION
Now that I've finished the transcription of `mm.c` I went through the TODOs in the code and changed a few things. The most significant thing here is a generalization of the list-indexing notation, so that I can use it for more than just PTEs and so that it closer matches the code.

Since these are minor changes, I'll merge them without review; this PR is just for documentation purposes.