### PR TITLE
Prove api_clear_memory

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -15,5 +15,6 @@ src/Concrete/Assumptions/Mpool.v
 src/Concrete/Assumptions/PageTables.v
 src/Concrete/MM/Datatypes.v
 src/Concrete/MM/Implementation.v
+src/Concrete/MM/Proofs.v
 src/Concrete/Api/Implementation.v
 src/Concrete/Api/Proofs.v

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -32,8 +32,10 @@ Proof.
          | |- context [let '(_,_) := ?x in _] =>
            rewrite (surjective_pairing x)
          | _ => progress break_match
-         | _ => eauto using mm_defrag_represents, mm_unmap_represents,
-                mm_identity_map_represents
+         | _ => apply mm_defrag_represents
+         | _ => apply mm_unmap_represents
+         | _ => apply mm_identity_map_represents
+         | _ => solver
          end.
 Qed.
 

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -2,9 +2,11 @@ Require Import Coq.Arith.PeanoNat.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.Tactics.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
 Require Import Hafnium.Concrete.Api.Implementation.
+Require Import Hafnium.Concrete.MM.Proofs.
 
 Lemma api_clear_memory_valid
       {cp : concrete_params} (conc : concrete_state) begin end_ ppool :
@@ -23,7 +25,17 @@ Lemma api_clear_memory_represents
   let conc' := snd (fst (api_clear_memory conc begin end_ ppool)) in
   exists abst', represents abst' conc'.
 Proof.
-Admitted. (* TODO *)
+  cbv [api_clear_memory].
+  repeat match goal with
+         | _ => progress basics
+         | _ => progress cbn [fst snd]
+         | |- context [let '(_,_) := ?x in _] =>
+           rewrite (surjective_pairing x)
+         | _ => progress break_match
+         | _ => eauto using mm_defrag_represents, mm_unmap_represents,
+                mm_identity_map_represents
+         end.
+Qed.
 
 Lemma api_share_memory_valid
       {cp : concrete_params} (conc : concrete_state)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -14,27 +14,27 @@ Section Proofs.
   Context {ap : @abstract_state_parameters paddr_t nat}
           {cp : concrete_params}.
 
-Lemma mm_identity_map_represents
-      (conc : concrete_state)
-      begin end_ mode ppool :
-  (exists abst, represents abst conc) ->
-  let conc' := snd (fst (mm_identity_map conc begin end_ mode ppool)) in
-  exists abst', represents abst' conc'.
-Admitted.
+  Lemma mm_identity_map_represents
+        (conc : concrete_state)
+        begin end_ mode ppool :
+    (exists abst, represents abst conc) ->
+    let conc' := snd (fst (mm_identity_map conc begin end_ mode ppool)) in
+    exists abst', represents abst' conc'.
+  Admitted.
 
-Lemma mm_defrag_represents
-      (conc : concrete_state)
-      ppool :
-  (exists abst, represents abst conc) ->
-  let conc' := fst (mm_defrag conc ppool) in
-  exists abst', represents abst' conc'.
-Admitted.
+  Lemma mm_defrag_represents
+        (conc : concrete_state)
+        ppool :
+    (exists abst, represents abst conc) ->
+    let conc' := fst (mm_defrag conc ppool) in
+    exists abst', represents abst' conc'.
+  Admitted.
 
-Lemma mm_unmap_represents
-      (conc : concrete_state)
-      begin end_ ppool :
-  (exists abst, represents abst conc) ->
-  let conc' := snd (fst (mm_unmap conc begin end_ ppool)) in
-  exists abst', represents abst' conc'.
-Admitted.
+  Lemma mm_unmap_represents
+        (conc : concrete_state)
+        begin end_ ppool :
+    (exists abst, represents abst conc) ->
+    let conc' := snd (fst (mm_unmap conc begin end_ ppool)) in
+    exists abst', represents abst' conc'.
+  Admitted.
 End Proofs.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -14,27 +14,31 @@ Section Proofs.
   Context {ap : @abstract_state_parameters paddr_t nat}
           {cp : concrete_params}.
 
+  Local Definition preserves_represents
+        (f : concrete_state -> concrete_state) : Prop :=
+    forall (ap : abstract_state_parameters) (cp : concrete_params)
+           (conc : concrete_state),
+      (exists abst, represents abst conc) ->
+      exists abst', represents abst' (f conc).
+
   Lemma mm_identity_map_represents
         (conc : concrete_state)
         begin end_ mode ppool :
-    (exists abst, represents abst conc) ->
-    let conc' := snd (fst (mm_identity_map conc begin end_ mode ppool)) in
-    exists abst', represents abst' conc'.
+    preserves_represents
+      (fun conc => snd (fst (mm_identity_map conc begin end_ mode ppool))).
   Admitted.
 
   Lemma mm_defrag_represents
         (conc : concrete_state)
         ppool :
-    (exists abst, represents abst conc) ->
-    let conc' := fst (mm_defrag conc ppool) in
-    exists abst', represents abst' conc'.
+    preserves_represents
+      (fun conc => fst (mm_defrag conc ppool)).
   Admitted.
 
   Lemma mm_unmap_represents
         (conc : concrete_state)
         begin end_ ppool :
-    (exists abst, represents abst conc) ->
-    let conc' := snd (fst (mm_unmap conc begin end_ ppool)) in
-    exists abst', represents abst' conc'.
+    preserves_represents
+      (fun conc => snd (fst (mm_unmap conc begin end_ ppool))).
   Admitted.
 End Proofs.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -1,0 +1,38 @@
+Require Import Coq.Arith.PeanoNat.
+Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.State.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.Tactics.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.MM.Implementation.
+
+(*** This file contains correctness proofs for the functions in mm.c, as
+     transcribed in MM/Implementation.v ***)
+
+Lemma mm_identity_map_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (conc : concrete_state)
+      begin end_ mode ppool :
+  (exists abst, represents abst conc) ->
+  let conc' := snd (fst (mm_identity_map conc begin end_ mode ppool)) in
+  exists abst', represents abst' conc'.
+Admitted.
+
+Lemma mm_defrag_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (conc : concrete_state)
+      ppool :
+  (exists abst, represents abst conc) ->
+  let conc' := fst (mm_defrag conc ppool) in
+  exists abst', represents abst' conc'.
+Admitted.
+
+Lemma mm_unmap_represents
+      {ap : abstract_state_parameters} {cp : concrete_params}
+      (conc : concrete_state)
+      begin end_ ppool :
+  (exists abst, represents abst conc) ->
+  let conc' := snd (fst (mm_unmap conc begin end_ ppool)) in
+  exists abst', represents abst' conc'.
+Admitted.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -1,10 +1,12 @@
 Require Import Coq.Arith.PeanoNat.
+Require Import Coq.Lists.List.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Util.Tactics.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.MM.Datatypes.
 Require Import Hafnium.Concrete.MM.Implementation.
 
 (*** This file contains correctness proofs for the functions in mm.c, as
@@ -16,10 +18,62 @@ Section Proofs.
 
   Local Definition preserves_represents
         (f : concrete_state -> concrete_state) : Prop :=
-    forall (ap : abstract_state_parameters) (cp : concrete_params)
-           (conc : concrete_state),
+    forall (conc : concrete_state),
       (exists abst, represents abst conc) ->
       exists abst', represents abst' (f conc).
+  Hint Unfold preserves_represents.
+
+  Lemma mm_free_page_pte_represents
+        (conc : concrete_state)
+        pte level ppool :
+    preserves_represents
+      (fun conc => fst (mm_free_page_pte conc pte level ppool)).
+  Admitted.
+
+  Lemma mm_replace_entry_represents
+        (conc : concrete_state)
+        begin t pte_index new_pte level flags ppool :
+    preserves_represents
+      (fun conc =>
+         snd (fst (mm_replace_entry
+                     conc begin t pte_index new_pte level flags ppool))).
+  Admitted.
+
+  Lemma mm_populate_table_pte_represents
+        (conc : concrete_state)
+        begin t pte_index level flags ppool :
+    preserves_represents
+      (fun conc =>
+         snd (fst (mm_populate_table_pte
+                     conc begin t pte_index level flags ppool))).
+  Admitted.
+
+  Lemma mm_map_level_represents
+        (conc : concrete_state)
+        t begin end_ attrs table level flags ppool :
+    preserves_represents
+      (fun conc =>
+         snd (fst (mm_map_level
+                     conc t begin end_ attrs table level flags ppool))).
+  Admitted.
+
+  Lemma mm_map_root_represents
+        (conc : concrete_state)
+        t begin end_ attrs root_level flags ppool :
+    preserves_represents
+      (fun conc =>
+         snd (fst (mm_map_root
+                     conc t begin end_ attrs root_level flags ppool))).
+  Admitted.
+
+  Lemma mm_ptable_identity_update_represents
+        (conc : concrete_state)
+        t pa_begin pa_end attrs flags ppool :
+    preserves_represents
+      (fun conc =>
+         snd (fst (mm_ptable_identity_update
+                     conc t pa_begin pa_end attrs flags ppool))).
+  Admitted.
 
   Lemma mm_identity_map_represents
         (conc : concrete_state)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -10,8 +10,11 @@ Require Import Hafnium.Concrete.MM.Implementation.
 (*** This file contains correctness proofs for the functions in mm.c, as
      transcribed in MM/Implementation.v ***)
 
+Section Proofs.
+  Context {ap : @abstract_state_parameters paddr_t nat}
+          {cp : concrete_params}.
+
 Lemma mm_identity_map_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
       (conc : concrete_state)
       begin end_ mode ppool :
   (exists abst, represents abst conc) ->
@@ -20,7 +23,6 @@ Lemma mm_identity_map_represents
 Admitted.
 
 Lemma mm_defrag_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
       (conc : concrete_state)
       ppool :
   (exists abst, represents abst conc) ->
@@ -29,10 +31,10 @@ Lemma mm_defrag_represents
 Admitted.
 
 Lemma mm_unmap_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
       (conc : concrete_state)
       begin end_ ppool :
   (exists abst, represents abst conc) ->
   let conc' := snd (fst (mm_unmap conc begin end_ ppool)) in
   exists abst', represents abst' conc'.
 Admitted.
+End Proofs.

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -65,7 +65,7 @@ Lemma execution_represents
 Proof.
   cbv [execute_trace]; intros; induction trace; [ basics; solver | ].
   destruct IHtrace as [abst IHtrace]. basics.
-  cbn [fold_right]. break_match.
+  cbn [fold_right]. break_match; intros.
   { (* case : api_clear_memory *)
     apply api_clear_memory_represents with (abst0:=abst).
     eapply IHtrace. }

--- a/coq-verification/src/Util/Tactics.v
+++ b/coq-verification/src/Util/Tactics.v
@@ -21,8 +21,17 @@ Ltac basics :=
 (* break up goal into multiple cases *)
 Ltac break_match :=
   match goal with
-  | |- context [match ?x with _ => _ end] => destruct x
-  | H : context [match ?x with _ => _ end] |- _ => destruct x
+  | |- context [match ?x with _ => _ end] =>
+    match type of x with
+    | sumbool _ _ => destruct x
+    end
+  | H : context [match ?x with _ => _ end] |- _ =>
+    match type of x with
+    | sumbool _ _ => destruct x
+    end
+  | |- context [match ?x with _ => _ end] => case_eq x; intro
+  | H : context [match ?x with _ => _ end] |- _ =>
+    let Heq := fresh in case_eq x; intro Heq; rewrite Heq in H
   end.
 
 (* solves relatively easy goals with some common methods *)


### PR DESCRIPTION
Prove `api_clear_memory` correct modulo a whole bunch of new proof stubs at the `mm.c` abstraction level (`api_clear_memory` doesn't need *all* these stubs, but I'll need to prove them eventually so I just put them in).