### PR TITLE
Start proofs about mm.c

### DIFF
--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -3,6 +3,7 @@ Require Import Coq.Lists.List.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.List.
 Require Import Hafnium.Util.Tactics.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
@@ -23,12 +24,24 @@ Section Proofs.
       exists abst', represents abst' (f conc).
   Hint Unfold preserves_represents.
 
-  Lemma mm_free_page_pte_represents
-        (conc : concrete_state)
-        pte level ppool :
+  Lemma mm_free_page_pte_represents (conc : concrete_state) pte level ppool :
     preserves_represents
       (fun conc => fst (mm_free_page_pte conc pte level ppool)).
-  Admitted.
+  Proof.
+    autounfold.
+    generalize dependent conc. generalize dependent pte.
+    generalize dependent ppool.
+    induction level; intros; cbn [mm_free_page_pte];
+      repeat match goal with
+             | _ => progress basics
+             | _ => progress cbn [fst snd]
+             | |- context [let '(_,_) := ?x in _] =>
+               rewrite (surjective_pairing x)
+             | _ => break_match
+             | _ => apply fold_right_invariant; [ | solver ]
+             | _ => solver
+             end.
+  Qed.
 
   Lemma mm_replace_entry_represents
         (conc : concrete_state)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -4,6 +4,7 @@ Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Util.List.
+Require Import Hafnium.Util.Loops.
 Require Import Hafnium.Util.Tactics.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
@@ -86,7 +87,16 @@ Section Proofs.
       (fun conc =>
          snd (fst (mm_map_level
                      conc t begin end_ attrs table level flags ppool))).
-  Admitted.
+  Proof.
+    autounfold; cbv [mm_map_level].
+    repeat match goal with
+           | _ => simplify_step
+           | _ => apply while_loop_invariant; [ | solver ]
+           | _ => apply mm_free_page_pte_represents
+           | _ => apply mm_replace_entry_represents
+           | _ => apply mm_populate_table_pte_represents
+           end.
+  Qed.
 
   Lemma mm_map_root_represents
         (conc : concrete_state)

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -115,6 +115,19 @@ Section NthDefault.
 End NthDefault.
 Hint Rewrite @nth_default_nil @nth_default_cons : push_nth_default.
 
+Section FoldRight.
+  Context {A B : Type}.
+
+  Lemma fold_right_invariant (P : B -> Prop) (f : A -> B -> B) b ls :
+    (forall a b, P b -> P (f a b)) ->
+    P b ->
+    P (fold_right f b ls).
+  Proof.
+    generalize dependent b; induction ls; intros;
+      cbn [fold_right]; eauto.
+  Qed.
+End FoldRight.
+
 (* Proofs about [firstn] and [skipn] *)
 Section FirstnSkipn.
   Context {A : Type}.

--- a/coq-verification/src/Util/Loops.v
+++ b/coq-verification/src/Util/Loops.v
@@ -1,4 +1,5 @@
 Require Import Coq.Lists.List.
+Require Import Hafnium.Util.Tactics.
 
 Definition continue := false.
 Definition break := true.
@@ -18,3 +19,22 @@ Definition while_loop
            else body s)
         (start, continue)
         (seq 0 max_iterations)).
+
+Lemma while_loop_invariant {state} (P : state -> Prop) max_iterations cond body :
+  forall start,
+    (forall s, cond s = true -> P s -> P (fst (body s))) ->
+    P start ->
+    P (@while_loop _ max_iterations cond start body).
+Proof.
+  cbv [while_loop]. generalize (seq 0 max_iterations) as l.
+  induction l;
+    repeat match goal with
+           | _ => progress cbn [fold_right fst snd]
+           | _ => progress basics
+           | |- context [let '(_,_) := ?x in _] =>
+             rewrite (surjective_pairing x)
+           | _ => break_match
+           | _ => inversion_bool
+           | _ => solver
+           end.
+Qed.

--- a/coq-verification/src/Util/Tactics.v
+++ b/coq-verification/src/Util/Tactics.v
@@ -42,3 +42,13 @@ Ltac solver :=
   | _ => congruence
   | _ => omega
   end.
+
+Ltac inversion_bool :=
+  match goal with
+  | H : (_ && _)%bool = true |- _ => apply Bool.andb_true_iff in H
+  | H : (_ || _)%bool = true |- _ => apply Bool.orb_true_iff in H
+  | H : negb _ = true |- _ => apply Bool.negb_true_iff in H
+  | H : (_ && _)%bool = false |- _ => apply Bool.andb_false_iff in H
+  | H : (_ || _)%bool = false |- _ => apply Bool.orb_false_iff in H
+  | H : negb _ = false |- _ => apply Bool.negb_false_iff in H
+  end.


### PR DESCRIPTION
On top of #32 

This PR proves the first few stubs in `MM/Proofs.v`. It also includes proofs about Coq's native `fold_right` loops-over-lists and my own while loop construction (which is build on `fold_right`) as helpers to the other proofs.

These proofs are pretty easy, because these few functions don't modify the state at all. Once we get to the next one (`mm_map_root`) we'll need to do some more complicated work.

Best reviewed commit-by-commit so the loop proofs are separated from the Hafnium-specific proofs.