### PR TITLE
Rough skeleton of mm_map_root proof

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -4,6 +4,7 @@ src/Concrete/Datatypes.v
 src/Concrete/Model.v
 src/Concrete/Notations.v
 src/Concrete/State.v
+src/Concrete/StateProofs.v
 src/Util/List.v
 src/Util/Loops.v
 src/Util/Tactics.v

--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -5,6 +5,7 @@ src/Concrete/Model.v
 src/Concrete/Notations.v
 src/Concrete/State.v
 src/Concrete/StateProofs.v
+src/Util/BinNat.v
 src/Util/List.v
 src/Util/Loops.v
 src/Util/Tactics.v

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -18,12 +18,12 @@ Proof.
 Qed.
 
 Lemma api_clear_memory_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
+      {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
       (abst : abstract_state) (conc : concrete_state)
       begin end_ ppool :
-  represents abst conc ->
+  represents_valid abst conc ->
   let conc' := snd (fst (api_clear_memory conc begin end_ ppool)) in
-  exists abst', represents abst' conc'.
+  exists abst', represents_valid abst' conc'.
 Proof.
   cbv [api_clear_memory].
   repeat match goal with
@@ -50,11 +50,11 @@ Proof.
 Qed.
 
 Lemma api_share_memory_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
+      {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
       (abst : abstract_state) (conc : concrete_state)
       vid addr size share current :
-  represents abst conc ->
+  represents_valid abst conc ->
   let conc' := snd (api_share_memory conc vid addr size share current) in
-  exists abst', represents abst' conc'.
+  exists abst', represents_valid abst' conc'.
 Proof.
 Admitted. (* TODO *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -462,7 +462,7 @@ Definition mm_map_level
   let '(s, begin, pa, table, pte_index, failed, ppool) :=
       while_loop
         (max_iterations := N.to_nat (end_ - begin))
-        (fun _ => (begin <? end_)%N)
+        (fun '(_,begin,_,_,_,_,_) => (begin <? end_)%N)
         (s, begin, pa, table, pte_index, false, ppool)
         (fun '(s, begin, pa, table, pte_index, failed, ppool) =>
            let pte := table.(entries) [[ pte_index ]] in
@@ -616,7 +616,7 @@ Definition mm_map_root
   let '(s, begin, table_index, failed, ppool) :=
       while_loop
         (max_iterations := N.to_nat (end_ - begin))
-        (fun _ => (begin <? end_)%N)
+        (fun '(_,begin,_,_,_) => (begin <? end_)%N)
         (s, begin, table_index, false, ppool)
         (fun '(s, begin, table_index, failed, ppool) =>
 
@@ -768,7 +768,7 @@ Fixpoint mm_ptable_get_attrs_level
   let '(begin, pte_index, got_attrs, attrs) :=
       while_loop
         (max_iterations := N.to_nat (end_ - begin))
-        (fun _ => (begin <? end_)%N)
+        (fun '(begin,_,_,_) => (begin <? end_)%N)
         (begin, pte_index, got_attrs, attrs)
         (fun '(begin, pte_index, got_attrs, attrs) =>
            let pte := table.(entries)[[ pte_index ]] in
@@ -905,7 +905,7 @@ Definition mm_vm_get_attrs
     let '(_, _, got_attrs, attrs) :=
         while_loop
           (max_iterations := N.to_nat (end_ - begin))
-          (fun _ => (begin <? end_)%N)
+          (fun '(begin,_,_,_) => (begin <? end_)%N)
           (begin, table_index, got_attrs, 0%N)
           (fun '(begin, table_index, got_attrs, attrs) =>
                let table := tables[[ table_index ]] in

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -1,13 +1,15 @@
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 Require Import Hafnium.AbstractModel.
-Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.State.
+Require Import Hafnium.Concrete.StateProofs.
 Require Import Hafnium.Util.List.
 Require Import Hafnium.Util.Loops.
 Require Import Hafnium.Util.Tactics.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Assumptions.PageTables.
 Require Import Hafnium.Concrete.MM.Datatypes.
 Require Import Hafnium.Concrete.MM.Implementation.
 
@@ -108,11 +110,19 @@ Section Proofs.
   Lemma mm_map_root_represents
         (conc : concrete_state)
         t begin end_ attrs root_level flags ppool :
+    let ret :=
+        mm_map_root
+          conc t begin end_ attrs root_level flags ppool in
+    let ppool' := snd ret in
+    let conc' := snd (fst ret) in
+    let success := fst (fst ret) in
+    let t_ptr := ptable_pointer_from_address t.(root) in
     forall abst,
       represents abst conc ->
-      represents TODO
-                 (snd (fst (mm_map_root
-                              conc t begin end_ attrs root_level flags ppool))).
+      represents (if success
+                  then abst
+                  else abstract_reassign_pointer abst conc t_ptr attrs)
+                 conc'.
   Admitted.
 
   Lemma mm_ptable_identity_update_represents

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -18,12 +18,12 @@ Section Proofs.
   Context {ap : @abstract_state_parameters paddr_t nat}
           {cp : concrete_params}.
 
-  Local Definition preserves_represents
+  Local Definition preserves_represents_valid
         (f : concrete_state -> concrete_state) : Prop :=
     forall (conc : concrete_state),
-      (exists abst, represents abst conc) ->
-      exists abst', represents abst' (f conc).
-  Hint Unfold preserves_represents.
+      (exists abst, represents_valid abst conc) ->
+      exists abst', represents_valid abst' (f conc).
+  Hint Unfold preserves_represents_valid.
 
   Ltac simplify_step :=
     match goal with
@@ -36,9 +36,9 @@ Section Proofs.
     end.
   Ltac simplify := repeat simplify_step.
 
+  (* mm_free_page_pte doesn't change the state *)
   Lemma mm_free_page_pte_represents (conc : concrete_state) pte level ppool :
-    preserves_represents
-      (fun conc => fst (mm_free_page_pte conc pte level ppool)).
+    fst (mm_free_page_pte conc pte level ppool) = conc.
   Proof.
     autounfold.
     generalize dependent conc. generalize dependent pte.
@@ -50,90 +50,99 @@ Section Proofs.
              end.
   Qed.
 
+  (* mm_replace_entry doesn't change the state (it does in C, but in the Coq
+     translation it returns a new table to the caller and the caller updates the
+     state) *)
   Lemma mm_replace_entry_represents
         (conc : concrete_state)
         begin t pte_index new_pte level flags ppool :
-    preserves_represents
-      (fun conc =>
-         snd (fst (mm_replace_entry
-                     conc begin t pte_index new_pte level flags ppool))).
+    snd (fst (mm_replace_entry
+                conc begin t pte_index new_pte level flags ppool)) = conc.
   Proof.
     autounfold; cbv [mm_replace_entry].
     repeat match goal with
            | _ => simplify_step
-           | _ => apply mm_free_page_pte_represents
+           | _ => rewrite mm_free_page_pte_represents
            end.
   Qed.
 
+  (* mm_populate_table_pte doesn't change the state (it does in C, but in the Coq
+     translation it returns a new table to the caller and the caller updates the
+     state) *)
   Lemma mm_populate_table_pte_represents
         (conc : concrete_state)
         begin t pte_index level flags ppool :
-    preserves_represents
-      (fun conc =>
-         snd (fst (mm_populate_table_pte
-                     conc begin t pte_index level flags ppool))).
+    snd (fst (mm_populate_table_pte
+                conc begin t pte_index level flags ppool)) = conc.
   Proof.
     autounfold; cbv [mm_populate_table_pte].
     repeat match goal with
            | _ => simplify_step
-           | _ => apply mm_replace_entry_represents
+           | _ => rewrite mm_replace_entry_represents
            end.
   Qed.
 
+  (* mm_map_level doesn't change the state (it does in C, but in the Coq
+     translation it returns a new table to the caller and the caller updates the
+     state) *)
   Lemma mm_map_level_represents
         (conc : concrete_state)
         t begin end_ attrs table level flags ppool :
-    preserves_represents
-      (fun conc =>
-         snd (fst (mm_map_level
-                     conc t begin end_ attrs table level flags ppool))).
+    (snd (fst (mm_map_level
+                 conc t begin end_ attrs table level flags ppool))) = conc.
   Proof.
     autounfold; cbv [mm_map_level].
     repeat match goal with
            | _ => simplify_step
            | _ => apply while_loop_invariant; [ | solver ]
-           | _ => apply mm_free_page_pte_represents
-           | _ => apply mm_replace_entry_represents
-           | _ => apply mm_populate_table_pte_represents
+           | _ => rewrite mm_free_page_pte_represents
+           | _ => rewrite mm_replace_entry_represents
+           | _ => rewrite mm_populate_table_pte_represents
            end.
   Qed.
+
+  (* placeholder; later there will be actual expressions for the new abstract
+     states *)
+  Axiom TODO : @abstract_state paddr_t nat.
 
   Lemma mm_map_root_represents
         (conc : concrete_state)
         t begin end_ attrs root_level flags ppool :
-    preserves_represents
-      (fun conc =>
-         snd (fst (mm_map_root
-                     conc t begin end_ attrs root_level flags ppool))).
+    forall abst,
+      represents abst conc ->
+      represents TODO
+                 (snd (fst (mm_map_root
+                              conc t begin end_ attrs root_level flags ppool))).
   Admitted.
 
   Lemma mm_ptable_identity_update_represents
         (conc : concrete_state)
         t pa_begin pa_end attrs flags ppool :
-    preserves_represents
-      (fun conc =>
-         snd (fst (mm_ptable_identity_update
-                     conc t pa_begin pa_end attrs flags ppool))).
+    forall abst,
+      represents abst conc ->
+      represents TODO
+                 (snd (fst (mm_ptable_identity_update
+                              conc t pa_begin pa_end attrs flags ppool))).
   Admitted.
 
   Lemma mm_identity_map_represents
         (conc : concrete_state)
         begin end_ mode ppool :
-    preserves_represents
+    preserves_represents_valid
       (fun conc => snd (fst (mm_identity_map conc begin end_ mode ppool))).
   Admitted.
 
   Lemma mm_defrag_represents
         (conc : concrete_state)
         ppool :
-    preserves_represents
+    preserves_represents_valid
       (fun conc => fst (mm_defrag conc ppool)).
   Admitted.
 
   Lemma mm_unmap_represents
         (conc : concrete_state)
         begin end_ ppool :
-    preserves_represents
+    preserves_represents_valid
       (fun conc => snd (fst (mm_unmap conc begin end_ ppool))).
   Admitted.
 End Proofs.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -6,6 +6,7 @@ Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.StateProofs.
+Require Import Hafnium.Util.BinNat.
 Require Import Hafnium.Util.List.
 Require Import Hafnium.Util.Loops.
 Require Import Hafnium.Util.Tactics.
@@ -123,15 +124,6 @@ Section Proofs.
       (abstract_reassign_pointer start_abst start_conc t_ptr attrs start_begin index)
       s.
 
-  (* TODO: move *)
-  Lemma N_to_nat_ltb (x y : N) :
-    (x <? y)%N = (N.to_nat x <? N.to_nat y).
-  Proof.
-    rewrite N.ltb_compare, Nat.ltb_compare.
-    rewrite Nnat.N2Nat.inj_compare.
-    reflexivity.
-  Qed.
-
   (* TODO:
      This proof says only that if success = true and commit = true
      then the abstract state changed. We need two more proofs for full
@@ -200,7 +192,7 @@ Section Proofs.
                repeat match goal with
                       | _ => progress basics
                       | p : _ * _ |- _ => destruct p
-                      | _ => apply N_to_nat_ltb
+                      | _ => apply N.to_nat_ltb
                       | _ => solver
                       end)). }
     6 : {
@@ -209,7 +201,7 @@ Section Proofs.
         repeat match goal with
                | _ => progress basics
                | p : _ * _ |- _ => destruct p
-               | _ => apply N_to_nat_ltb
+               | _ => apply N.to_nat_ltb
                | _ => solver
                end.
     solver. }

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -39,29 +39,27 @@ Definition obeys_invariants
            {ap : abstract_state_parameters} {cp : concrete_params}
            (conc : concrete_state) : Prop :=
   exists abst : abstract_state,
-    represents abst conc /\ AbstractModel.obeys_invariants abst.
+    represents_valid abst conc /\ AbstractModel.obeys_invariants abst.
 
-(* because [represents] includes [AbstractModel.is_valid], and we've proved all
-   valid abstract states obey the invariants, it's sufficient to just prove
-   [represents] *)
+(* because [represents_valid] includes [AbstractModel.is_valid], and we've proved
+   all valid abstract states obey the invariants, it's sufficient to just prove
+   [represents_valid] *)
 Lemma represents_obeys_invariants
       {ap : abstract_state_parameters} {cp : concrete_params}
       (conc : concrete_state) :
-  (exists abst, represents abst conc) ->
+  (exists abst, represents_valid abst conc) ->
   obeys_invariants conc.
 Proof.
-  cbv [represents obeys_invariants]; basics.
+  cbv [represents_valid obeys_invariants]; basics.
   eexists; basics; try solver; [ ].
-  apply (valid_obeys_invariants
-           (addr_eq_dec:=paddr_t_eq_dec) (vm_id_eq_dec:=Nat.eq_dec)).
-  eauto.
+  eauto using valid_obeys_invariants.
 Qed.
 
 Lemma execution_represents
-      {ap : abstract_state_parameters} {cp : concrete_params}
+      {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
       (start_state : concrete_state) (trace : list api_call) :
-  (exists abst, represents abst start_state) ->
-  exists abst, represents abst (execute_trace start_state trace).
+  (exists abst, represents_valid abst start_state) ->
+  exists abst, represents_valid abst (execute_trace start_state trace).
 Proof.
   cbv [execute_trace]; intros; induction trace; [ basics; solver | ].
   destruct IHtrace as [abst IHtrace]. basics.

--- a/coq-verification/src/Concrete/Notations.v
+++ b/coq-verification/src/Concrete/Notations.v
@@ -19,6 +19,7 @@ Bind Scope N_scope with uintvaddr_t.
 
 Notation "! x" := (negb x) (at level 200) : bool_scope.
 Notation "x != y" := (negb (N.eqb x y)) (at level 199) : bool_scope.
+Notation "x != y" := (negb (N.eqb x y)) (at level 199) : N_scope.
 
 Coercion N.of_nat : nat >-> N. (* change nat to N automatically *)
 Set Printing Coercions. (* when printing, show N.of_nat explicitly *)

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -95,13 +95,10 @@ Definition haf_page_owned
 Arguments owned_by {_} {_} _.
 Arguments accessible_by {_} {_} _.
 Definition represents
-           {ap : abstract_state_parameters}
            {cp : concrete_params}
            (abst : @abstract_state paddr_t nat)
            (conc : concrete_state) : Prop :=
   is_valid conc
-  /\ AbstractModel.is_valid
-       (addr_eq_dec:=paddr_t_eq_dec) (vm_id_eq_dec:=Nat.eq_dec) abst
   /\ (forall (vid : nat) (a : paddr_t),
       In (inl vid) (abst.(accessible_by) a) <->
          (exists v : vm,
@@ -115,6 +112,14 @@ Definition represents
   /\ (forall (a : paddr_t),
          abst.(owned_by) a = inr hid <-> conc.(haf_page_owned) a)
 .
+Definition represents_valid
+           {ap : abstract_state_parameters}
+           {cp : concrete_params}
+           (abst : @abstract_state paddr_t nat)
+           (conc : concrete_state) : Prop :=
+  represents abst conc
+  /\ AbstractModel.is_valid
+       (addr_eq_dec:=paddr_t_eq_dec) (vm_id_eq_dec:=Nat.eq_dec) abst.
 
 Definition abstract_state_equiv
            (s1 s2 : @abstract_state paddr_t nat) : Prop :=

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -49,7 +49,7 @@ Definition reassign_pointer
       (fun ptr' =>
          if ptable_pointer_eq_dec ptr ptr'
          then t
-         else s.(ptable_deref) ptr);
+         else s.(ptable_deref) ptr');
     api_page_pool := s.(api_page_pool);
   |}.
 

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -1,0 +1,167 @@
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.NArith.BinNat.
+Require Import Coq.Lists.List.
+Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.State.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Notations.
+Require Import Hafnium.Util.List.
+Require Import Hafnium.Util.Tactics.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.ArchMM.
+Require Import Hafnium.Concrete.Assumptions.Constants.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Assumptions.PageTables.
+Require Import Hafnium.Concrete.MM.Datatypes.
+
+(*** This file contains correctness proofs about the relationship between
+     concrete and abstract states. ***)
+
+Section Proofs.
+  Context {ap : @abstract_state_parameters paddr_t nat}
+          {cp : concrete_params}.
+
+  (* if two concrete states are equivalent and an abstract state represents one
+     of them, then it also represents the other. *)
+  Lemma represents_proper abst conc conc' :
+    (forall ptr, conc.(ptable_deref) ptr = conc'.(ptable_deref) ptr) ->
+    (conc.(api_page_pool) = conc'.(api_page_pool)) ->
+    represents abst conc ->
+    represents abst conc'.
+  Admitted.
+
+  (* if the new table is the same as the old, abstract state doesn't change *)
+  Lemma reassign_pointer_noop_represents conc ptr t abst :
+    represents abst conc ->
+    conc.(ptable_deref) ptr = t ->
+    represents abst (conc.(reassign_pointer) ptr t).
+  Proof.
+    repeat match goal with
+           | _ => progress basics
+           | _ => progress cbn [reassign_pointer ptable_deref]
+           | _ => break_match
+           | _ => solver
+           | _ => apply represents_proper with (conc:=conc); eauto; [ ]
+           end.
+  Qed.
+
+  (* given a sequence of page table indices, says whether the address is found
+     under the same sequence of page table indexing *)
+  Definition is_under_path (indices : list nat) (addr : uintpaddr_t) : bool :=
+    forallb
+      (fun '(lvl, i) => get_index lvl addr =? i)
+      (combine (seq 0 4) indices).
+
+  (* We haven't formalized anywhere that pointers don't repeat, so we return a
+     list of all locations where the provided pointer exists even though we
+     expect there is only one. *)
+  Fixpoint index_sequences_to_pointer' (ptable_deref : ptable_pointer -> mm_page_table)
+           (ptr : ptable_pointer) (root : ptable_pointer) (lvls_to_go : nat)
+    : list (list nat) :=
+    match lvls_to_go with
+    | 0 => nil
+    | S lvls_to_go' =>
+      let lvl := 4 - lvls_to_go in
+      if ptable_pointer_eq_dec root ptr
+      then cons nil nil
+      else
+        flat_map
+          (fun index =>
+             let ptable := ptable_deref root in
+             match get_entry ptable index with
+             | Some pte =>
+               if arch_mm_pte_is_table pte lvl
+               then
+                 let next_root :=
+                     ptable_pointer_from_address
+                       (arch_mm_table_from_pte pte lvl) in
+                 map
+                   (cons index)
+                   (index_sequences_to_pointer'
+                      ptable_deref ptr next_root lvls_to_go')
+               else nil
+             | None => nil
+             end)
+          (seq 0 MM_PTE_PER_PAGE)
+    end.
+  Definition index_sequences_to_pointer (ptable_deref : ptable_pointer -> mm_page_table)
+             (ptr : ptable_pointer) (root : ptable_pointer) : list (list nat) :=
+    index_sequences_to_pointer' ptable_deref ptr root 4.
+
+  Definition abstract_reassign_pointer_for_entity
+             (abst : abstract_state) (conc : concrete_state)
+             (ptr : ptable_pointer) (owned valid : bool)
+             (e : entity_id) (root_ptable : ptable_pointer)
+    : abstract_state :=
+    let paths := index_sequences_to_pointer
+                   conc.(ptable_deref) ptr root_ptable in
+    let under_pointer : uintpaddr_t -> bool :=
+        fun addr =>
+          existsb (fun p => is_under_path p addr) paths in
+    let eq_dec := @entity_id_eq_dec _ Nat.eq_dec in
+    {|
+      accessible_by :=
+        (fun a =>
+           if (valid && under_pointer (pa_addr a))%bool
+           then nodup eq_dec (e :: abst.(accessible_by) a)
+           else remove eq_dec e (abst.(accessible_by) a));
+      owned_by :=
+        (fun a =>
+           if (owned && under_pointer (pa_addr a))%bool
+           then e
+           else
+             if eq_dec e (abst.(owned_by) a)
+             then inr hid (* TODO: make owned_by an [option] so that unowned
+                             memory is representable *)
+             else abst.(owned_by) a)
+    |}.
+
+  (* Update the abstract state to make everything under the given pointer have
+     the provided new owned/valid bits. *)
+  Definition abstract_reassign_pointer
+             (abst : abstract_state) (conc : concrete_state)
+             (ptr : ptable_pointer) (attrs : attributes) : abstract_state :=
+    (* first, get the owned/valid bits *)
+    let stage1_mode := arch_mm_stage1_attrs_to_mode attrs in
+    let stage2_mode := arch_mm_stage2_attrs_to_mode attrs in
+    let s1_owned := ((stage1_mode & MM_MODE_UNOWNED) != 0)%N in
+    let s1_valid := ((stage1_mode & MM_MODE_INVALID) != 0)%N in
+    let s2_owned := ((stage2_mode & MM_MODE_UNOWNED) != 0)%N in
+    let s2_valid := ((stage2_mode & MM_MODE_INVALID) != 0)%N in
+
+    (* update the state with regard to Hafnium *)
+    let abst :=
+        abstract_reassign_pointer_for_entity
+          abst conc ptr s1_owned s1_valid (inr hid) hafnium_root_ptable in
+
+    (* update the state with regard to each VM *)
+    fold_right
+      (fun (v : vm) (abst : abstract_state) =>
+         abstract_reassign_pointer_for_entity
+           abst conc ptr s2_owned s2_valid (inl v.(vm_id)) v.(vm_root_ptable))
+      abst
+      vms.
+
+  Definition has_uniform_attrs
+             (ptable_deref : ptable_pointer -> mm_page_table)
+             (t : mm_page_table) (level : nat) (attrs : attributes) : Prop :=
+    forall (a : uintpaddr_t) (pte : pte_t),
+      page_lookup' ptable_deref a t (4 - level) = Some pte ->
+      forall lvl, arch_mm_pte_attrs pte lvl = attrs.
+
+  Lemma reassign_pointer_represents conc ptr t abst :
+    represents abst conc ->
+    forall attrs level,
+      has_uniform_attrs conc.(ptable_deref) t level attrs ->
+      represents (abstract_reassign_pointer abst conc ptr attrs)
+                 (conc.(reassign_pointer) ptr t).
+  Proof.
+    cbv [reassign_pointer represents].
+    cbv [is_valid].
+    cbv [vm_page_valid haf_page_valid vm_page_owned haf_page_owned].
+    cbn [ptable_deref].
+    basics; try solver.
+    (* 4 subgoals *)
+  Admitted.
+End Proofs.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -1,0 +1,14 @@
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.NArith.BinNat.
+Require Import Coq.NArith.Nnat.
+Local Open Scope N_scope.
+
+Module N.
+  Lemma to_nat_ltb (x y : N) :
+    (x <? y)%N = (N.to_nat x <? N.to_nat y)%nat.
+  Proof.
+    rewrite N.ltb_compare, Nat.ltb_compare.
+    rewrite N2Nat.inj_compare.
+    reflexivity.
+  Qed.
+End N.


### PR DESCRIPTION
On top of #34 

This PR lays the groundwork for the most complex proofs. It involves multiple stages.

1. I now distinguish between a concrete state having any abstract representation and it having a valid one, since the validity conditions of abstract states are allowed to be broken in intermediate stages.
2. A new file, `StateProofs.v`, provides some assistance with reasoning about the relationships between abstract and concrete states as they change.
3. There is now a rough outline of the proof for the most complex case of `mm_map_root` (when it succeeds and commit is true, so things actually get changed). It has various admits at lower levels of abstraction that need to be factored out into their own proofs.

This proof requires substantially more work, but I'm pull-requesting the rough version to make the future changes less monolithic.