### PR TITLE
Prove most complex case of mm_map_root modulo assumptions at lower abstraction levels

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -20,9 +20,13 @@ Axiom pa_difference : paddr_t -> paddr_t -> size_t.
 
 Axiom ipa_addr : ipaddr_t -> uintpaddr_t.
 
+Axiom va_init : uintvaddr_t -> vaddr_t.
+
 Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.
 
 Axiom va_from_pa : paddr_t -> vaddr_t.
+
+Axiom pa_from_va : vaddr_t -> paddr_t.
 
 Axiom pa_from_ipa : ipaddr_t -> paddr_t.
 

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -43,3 +43,6 @@ Axiom mm_modes_distinct :
            MM_MODE_UNOWNED_index; MM_MODE_SHARED_index].
 Axiom mm_flags_distinct :
   NoDup [MM_FLAG_STAGE1_index; MM_FLAG_COMMIT_index].
+
+(* assume that PAGE_BITS is positive *)
+Axiom PAGE_BITS_pos : 0 < PAGE_BITS.

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -29,3 +29,8 @@ Axiom mpool_free : mpool -> ptable_pointer -> mpool.
    to allocate *)
 Axiom mpool_alloc_contiguous :
   mpool -> size_t -> size_t -> option (mpool * list ptable_pointer).
+
+
+(* N.B. this is for proofs, not code; it's not part of the header file and exists
+   purely conceptually *)
+Axiom mpool_contains : mpool -> ptable_pointer -> Prop.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -221,14 +221,12 @@ Section Proofs.
                start_abst)
             s))).
 
-  (* TODO: include 0 < PAGE_BITS axiom *)
   Lemma mm_start_of_next_block_shift a level :
-    (0 < PAGE_BITS)%N ->
     (mm_start_of_next_block a (mm_entry_size level)
                             >> (PAGE_BITS + level * PAGE_LEVEL_BITS))%N =
     ((a >> (PAGE_BITS + level * PAGE_LEVEL_BITS)) + 1)%N.
   Proof.
-    intros.
+    intros. pose proof PAGE_BITS_pos.
     cbv [mm_start_of_next_block mm_entry_size].
     rewrite !Nnat.N2Nat.id, N.shiftr_land, N.lnot_shiftr.
     rewrite N.shiftr_eq_0 with (a:=((_ << _) - 1)%N) by

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -2,6 +2,7 @@ Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.BinNat.
+Require Import Coq.omega.Omega.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.
@@ -43,6 +44,8 @@ Section Proofs.
       rewrite (surjective_pairing x) in H
     | _ => break_match
     | _ => solver
+    | H : break = continue |- _ => cbv [break continue] in H; solver
+    | H : continue = break |- _ => cbv [break continue] in H; solver
     end.
   Ltac simplify := repeat simplify_step.
 
@@ -114,38 +117,145 @@ Section Proofs.
   Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level
         flags ppool :
     let ret :=
-        mm_map_level conc begin end_ pa attrs table level flags ppool in
+        mm_map_level conc begin end_ pa attrs table (level-1) flags ppool in
     let success := fst (fst (fst ret)) in
     let table := snd (fst (fst ret)) in
     let conc' := snd (fst ret) in
     let ppool' := snd ret in
-    let begin : nat := mm_index begin level in
-    let end_ : nat := mm_index end_ level in
-    has_uniform_attrs conc'.(ptable_deref) table level attrs begin end_.
+    has_uniform_attrs conc.(ptable_deref) table (level - 1) attrs begin end_.
   Admitted.
 
   (* placeholder; later there will be actual expressions for the new abstract
      states *)
   Axiom TODO : @abstract_state paddr_t nat.
 
-  (* TODO: we know that all the mm_map_level steps succeed because we
-  know that the whole thing succeeds. But how do we use that in the
-  invariant? *)
+
+  (* Need to figure out alignment situation!
+     - condition of while loop is [end <= begin]
+     - [end] is rounded *up* to the nearest page
+     - [mm_start_of_next_block]...what does it do? I think it gets the address of
+       the next table entry at the given level, as suggested by incrementation of
+       [table_index]
+        * it zeroes out all the bits below the provided block size, which is mm_entry_size level, so yes
+     
+     if [end] is not aligned to the entry size, then what will happen?
+        well, we'll eventually get to a point where [mm_index begin level = mm_index end level], but begin < end because begin is aligned
+        we'll do that reassignment and the range checks will keep things honest
+        then mm_index begin level = S (mm_index end level) and begin >= end; break
+
+     if [end] is aligned, then what will happen?
+        as soon as [mm_index begin level = mm_index end level], [begin = end] and we break
+
+     so...while_loop_end_exact is NOT the right thing, quite. We don't get
+     [begin = end_]; we get [begin >= end_] and
+     [mm_index begin level = if end_aligned_to_entry_size
+                             then mm_index end level
+                             else S (mm_index end level) ]
+     
+     if we know [mm_index begin level <= S (mm_index end level)], does that help?
+
+   *)
+
+  (* maybe we need some part of the concrete state to say where each
+  ptable_pointer is, exactly one location. They can be either in mpool
+  or somewhere in a page table, but this would enforce by construction
+  that they're not repeated... *)
+  Axiom pointer_in_table :
+    (Datatypes.ptable_pointer -> mm_page_table) ->
+    Datatypes.ptable_pointer -> mm_page_table -> Prop.
+
+
+  Definition deref_noncircular (c : concrete_state) : Prop :=
+    forall ptr,
+      ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr).
+
+  Axiom mpool_contains : mpool -> Datatypes.ptable_pointer -> Prop.
+
+  Definition pointers_ok (c : concrete_state) (ppool : mpool) : Prop :=
+    deref_noncircular c
+    /\ (forall ptr,
+           mpool_contains ppool ptr <->
+           (forall ptr2, ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr2))).
+
+  (* TODO : is this the right approach? *)
+  Lemma mm_map_level_noncircular c begin end_ pa attrs ptr level flags ppool :
+    pointers_ok c ppool ->
+    let ret := mm_map_level
+                 c begin end_ pa attrs (ptable_deref c ptr) level flags ppool in
+    let table := snd (fst (fst ret)) in
+    ~ pointer_in_table (ptable_deref c) ptr table.
+  Admitted. (* TODO *)
+ 
+  Definition is_start_of_block (a : ptable_addr_t) (level : nat) : Prop :=
+    (a & (mm_entry_size level - 1))%N = 0.
+
+  Lemma mm_start_of_next_block_is_start a level :
+    is_start_of_block (mm_start_of_next_block a (mm_entry_size level)) level.
+  Admitted. (* TODO *)
+
+  (* dumb wrapper for one of the invariants so it doesn't get split too early *)
+  Definition is_begin_or_block_start
+             (start_begin begin : ptable_addr_t) root_level : Prop :=
+      (begin = start_begin \/ is_start_of_block begin root_level).
+
+  (* TODO: we're not actually using the starting concrete state all
+  the time; the concrete state has to change. But how exactly can we
+  encode that? *)
+  (* In reality, it shouldn't matter that the concrete state is
+  changing because we only care about the subset of it that leads to
+  the pointers we're changing, and those pointers should all be on the
+  same level and not be in each other's paths. Can we encode this by
+  passing in the index sequences to the pointer, perhaps, instead of
+  the entire concrete state? *)
+  (* Can we say each pointer has exactly one index sequence and they
+  don't affect each other's index sequences and then pass in an index
+  sequence to abstract_reassign_pointer instead of a concrete state
+  and a pointer? *)
+  (* Should we do away with ptable_pointer entirely? *)
+  (* what if, instead of ptable_pointer, we had something that
+  indicated position-from-root? Something like the index sequences? *)
+  (* the beauty of the current solution is that it *does* remap every
+  location exactly as happens in concrete state. But can we preserve
+  that beauty? Where exactly would we run into problems with allowing
+  for repeats of the same pointer? *)
+  (* well, somewhere we need to know that the concrete state doesn't
+  change stuff in random other places...we *need* the property that
+  ptable_pointers don't repeat themselves *)
+  (* in this case, that reasoning would look like:
+     - every ptable_pointer has exactly one index_sequence from exactly one table (reassign_pointer preserves that property because mm_map_level output fits certain conditions)
+     - none of the reassignments we do will change each other's index sequence, because they can't change anything shorter than themselves
+     - if the index_sequence for the pointer passed into abstract_reassign_pointer hasn't changed, we can switch out concrete states
+   *)
   Definition mm_map_root_loop_invariant
-             start_abst start_conc t_ptrs start_begin attrs root_level
+             start_abst start_conc t_ptrs start_begin end_ attrs root_level
              (state : concrete_state * ptable_addr_t * size_t * bool * mpool)
     : Prop :=
     let '(s, begin, table_index, failed, ppool) := state in
-    let index := mm_index begin root_level in
-    table_index = index /\
+    let index := table_index - mm_index start_begin root_level in
+    let end_index := mm_index end_ root_level in
     (failed = true \/
-     represents
-       (fold_right
-          (fun t_ptr abst =>
-             abstract_reassign_pointer abst start_conc t_ptr attrs start_begin index)
-          start_abst
-          (firstn table_index t_ptrs))
-       s).
+     (table_index = mm_index begin root_level
+      /\ (start_begin <= begin)%N
+      /\ (begin <= mm_level_end end_ root_level)%N
+      /\ pointers_ok s ppool
+      /\ is_begin_or_block_start start_begin begin root_level
+      /\ (Forall (fun t_ptr =>
+                    Forall
+                      (fun root_ptr =>
+                         index_sequences_to_pointer
+                           start_conc.(ptable_deref) t_ptr root_ptr
+                         = index_sequences_to_pointer
+                             s.(ptable_deref) t_ptr root_ptr)
+                      (hafnium_root_ptable :: map vm_root_ptable vms))
+                 t_ptrs)
+      /\ (represents
+            (fold_left
+               (fun abst t_ptr =>
+                  abstract_reassign_pointer
+                    abst start_conc t_ptr attrs start_begin end_)
+               (firstn index t_ptrs)
+               start_abst)
+            s))).
 
   (* TODO: move *)
   Lemma N_lnot_0_r a : N.lnot a 0 = a.
@@ -209,6 +319,162 @@ Section Proofs.
        precondition in terms of mm_level_end. *)
   Admitted.
 
+  Lemma mm_index_le_mono a b level :
+    (a <= b)%N ->
+    (b <= mm_level_end a level)%N ->
+    mm_index a level <= mm_index b level.
+  Admitted. (* TODO *)
+
+  (* TODO: move *)
+  Lemma firstn_snoc {A} i ls d :
+    i < length ls ->
+    @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
+  Admitted. (* TODO *)
+
+  (* TODO: move *)
+  Lemma abstract_reassign_pointer_for_entity_change_concrete
+        abst conc conc' ptr owned valid e root_ptr begin end_ :
+    index_sequences_to_pointer conc.(ptable_deref) ptr root_ptr
+    = index_sequences_to_pointer conc'.(ptable_deref) ptr root_ptr ->
+    abstract_reassign_pointer_for_entity
+      abst conc ptr owned valid e root_ptr begin end_
+    = abstract_reassign_pointer_for_entity
+        abst conc' ptr owned valid e root_ptr begin end_.
+  Proof.
+    cbv beta iota delta [abstract_reassign_pointer_for_entity].
+    intro Heq. rewrite Heq. reflexivity.
+  Qed.
+
+  (* TODO : move *)
+  Lemma fold_right_ext {A B} (f g : A -> B -> B) b ls :
+    (forall a b, In a ls -> f a b = g a b) ->
+    fold_right f b ls = fold_right g b ls.
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma fold_left_ext {A B} (f g : B -> A -> B) b ls :
+    (forall a b, In b ls -> f a b = g a b) ->
+    fold_left f ls b = fold_left g ls b.
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma fold_left_nil {A B} (f : B -> A -> B) b :
+    fold_left f nil b = b.
+  Proof. reflexivity. Qed.
+  Hint Rewrite @fold_left_nil : push_fold_left.
+
+  (* TODO : move *)
+  Lemma Forall_map {A B} (P : B -> Prop) (f : A -> B) ls :
+    Forall P (map f ls) -> Forall (fun a => P (f a)) ls.
+  Admitted. (* TODO *)
+
+  (* TODO: move *)
+  Lemma abstract_reassign_pointer_change_concrete
+        abst conc conc' ptr attrs begin_index end_index :
+    Forall (fun root_ptr =>
+              index_sequences_to_pointer conc.(ptable_deref) ptr root_ptr
+              = index_sequences_to_pointer conc'.(ptable_deref) ptr root_ptr)
+            (hafnium_root_ptable :: map vm_root_ptable vms) ->
+    abstract_reassign_pointer abst conc ptr attrs begin_index end_index
+    = abstract_reassign_pointer abst conc' ptr attrs begin_index end_index.
+  Proof.
+    cbv [abstract_reassign_pointer].
+    repeat match goal with
+           | _ => progress basics
+           | _ => progress invert_list_properties
+           | H : _ |- _ => apply Forall_map in H; rewrite Forall_forall in H
+           | _ =>
+             rewrite abstract_reassign_pointer_for_entity_change_concrete
+               with (conc':=conc') by eauto
+           | _ => apply fold_right_ext
+           | _ => solve
+                    [auto using
+                          abstract_reassign_pointer_for_entity_change_concrete]
+           end.
+  Qed.
+
+  (* TODO : move *)
+  Lemma nth_default_skipn {A} (d:A) i j ls :
+    nth_default d (skipn i ls) j = nth_default d ls (j + i).
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma nth_default_firstn_low {A} (d:A) i j ls :
+    j < i ->
+    nth_default d (firstn i ls) j = nth_default d ls j.
+  Admitted. (* TODO *)
+
+  Lemma mm_level_end_le a level : (a <= mm_level_end a level)%N.
+  Admitted. (* TODO *)
+
+  Definition is_root (level : nat) : Prop :=
+    exists flags, level = mm_max_level flags + 1.
+
+  Lemma root_pos level : is_root level -> 0 < level.
+  Proof. cbv [is_root]; simplify. Qed.
+
+  (* At the root level, every address has the same level_end *)
+  Lemma mm_level_end_root_eq root_level :
+    is_root root_level ->
+    forall a b, mm_level_end a root_level = mm_level_end b root_level.
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma In_nth_default_firstn {A} (d:A) i j ls :
+    i < j ->
+    In (nth_default d ls i) (firstn j ls).
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma In_nth_default_skipn {A} (d:A) i j ls :
+    j <= i ->
+    In (nth_default d ls i) (skipn j ls).
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma In_nth_default_skipn_firstn {A} (d:A) i j k ls :
+    j <= i < k->
+    In (nth_default d ls i) (skipn j (firstn k ls)).
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  (* has_uniform_attrs doesn't care if we reassign the pointer we started from *)
+  (* TODO : will need some kind of precondition saying the pointer doesn't repeat *)
+  Lemma has_uniform_attrs_reassign_pointer c ptr new_table t level attrs begin end_:
+    ~ pointer_in_table (ptable_deref c) ptr t ->
+    has_uniform_attrs (ptable_deref c) t level attrs begin end_ ->
+    has_uniform_attrs
+      (ptable_deref (reassign_pointer c ptr new_table))
+      t level attrs begin end_.
+  Admitted. (* TODO *)
+
+  (* TODO: move *)
+  (* has_uniform_attrs is trivially true for things before the start of the given
+     table; therefore, we can arbitrarily expand the range in that direction. *)
+  Lemma has_uniform_attrs_expand_range
+        deref table level attrs begin start end_ :
+    is_start_of_block start (S level) ->
+    (begin <= start)%N ->
+    has_uniform_attrs deref table level attrs start end_ ->
+    has_uniform_attrs deref table level attrs begin end_.
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  (* TODO : probably will need preconditions about pointers being noncircular *)
+  Lemma abstract_reassign_pointer_root abst conc root_ptr attrs begin end_ :
+    represents
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         (mm_page_table_from_pa root_ptr)
+         abst)
+      conc ->
+    represents
+      (abstract_reassign_pointer abst conc (ptable_pointer_from_address root_ptr)
+                                 attrs begin end_)
+      conc.
+  Admitted. (* TODO *)
+
   (* TODO:
      This proof says only that if success = true and commit = true
      then the abstract state changed. We need two more proofs for full
@@ -216,6 +482,10 @@ Section Proofs.
      unchanged, and another saying that if success = true and commit =
      false, then success = true when the function is run again on the
      (unchanged) output state. *)
+  (* mm_level_end with level=root_level should be the end of the *root* ptable -- that means
+     mm_level_end begin root_level = mm_level_end end_ root_level *)
+  (* since abstract_reassign_pointer doesn't do anything if the
+  addresses given are out of range, we can reassign from root *)
   Lemma mm_map_root_represents_commit
         (conc : concrete_state)
         t begin end_ attrs root_level flags ppool :
@@ -225,100 +495,196 @@ Section Proofs.
     let ppool' := snd ret in
     let conc' := snd (fst ret) in
     let success := fst (fst ret) in
-    let t_ptrs := mm_page_table_from_pa t.(root) in
     let begin_index := mm_index begin root_level in
     let end_index := mm_index end_ root_level in
+    let t_ptrs :=
+        skipn begin_index
+              (firstn (S end_index) (mm_page_table_from_pa t.(root))) in
     success = true ->
     ((flags & MM_FLAG_COMMIT) != 0)%N = true ->
     (begin <= end_)%N ->
-    end_index < length t_ptrs ->
+    (* before calling mm_map_root, we have rounded end_ up to the nearest page,
+       and we have capped it to not go beyond the end of the table *)
+    end_index < length (mm_page_table_from_pa t.(root)) ->
+    (* we need to know we're actually at the root level *)
+    is_root root_level ->
+    (* nothing weird and circular going on with pointers *)
+    pointers_ok conc ppool ->
     forall abst,
       represents abst conc ->
-      represents (fold_right
-                    (fun t_ptr abst =>
+      represents (fold_left
+                    (fun abst t_ptr =>
                        abstract_reassign_pointer
-                         abst conc t_ptr attrs begin_index end_index)
-                    abst t_ptrs)
+                         abst conc t_ptr attrs begin end_)
+                    t_ptrs abst)
                  conc'.
   Proof.
     cbv zeta. cbv [mm_map_root].
     simplify.
 
-    let t_ptrs := constr:(mm_page_table_from_pa t.(root)) in
-    let start_begin := constr:(mm_index begin root_level) in
+    pose proof (root_pos root_level ltac:(auto)). 
+
+    let begin_index := constr:(mm_index begin root_level) in
+    let end_index := constr:(mm_index end_ root_level) in
+    let t_ptrs := constr:(skipn begin_index
+                                (firstn (S end_index)
+                                        (mm_page_table_from_pa t.(root)))) in
     match goal with
     | |- context [@while_loop _ ?iter ?cond ?start ?body] =>
       assert (mm_map_root_loop_invariant
-                abst conc t_ptrs start_begin attrs root_level
+                abst conc t_ptrs begin end_ attrs root_level
                 (@while_loop _ iter cond start body));
         [ apply while_loop_invariant | ]
     end;
-      cbv [mm_map_root_loop_invariant] in *; simplify;
-        repeat inversion_bool;
-        rewrite ?mm_map_level_represents.
-    { rewrite mm_index_start_of_next_block; reflexivity. }
-    { rewrite mm_index_start_of_next_block; reflexivity. }
-    { right.
-      cbn [firstn fold_right].
-      rewrite ?mm_map_level_represents.
-        cbv [mm_map_root_loop_invariant] in *; simplify.
-        right.
-          rewrite ?mm_map_level_represents
-    end.
-    Check while_loop_invariant.
-    { (* TODO: in this case, the map_level step failed, so we can't have returned success. *)
-      
-      Check reassign_pointer_represents.
-      Print mm_page_table_from_pa.
-      Check ptable_pointer_from_address.
-      SearchAbout s.
-    3:rewrite abstract_reassign_pointer_trivial; solver.
-    1-2: admit. (* mm_map_level layer *)
+      cbv [mm_map_root_loop_invariant] in *;
+      rewrite ?mm_map_level_represents; [ | | ].
+    { (* main case : prove invariant holds over step *)
 
-    match goal with
-    | H : represents (?f ?i) ?x |- represents (?f ?j) ?x =>
-      assert (i = j); [clear H | solver]
-    end.
+      (* conclude that mm_map_level succeeded *)
+      simplify; repeat inversion_bool; [ ].
+      right; rewrite !mm_map_level_represents.
 
+      (* split into the invariant clauses *)
+      simplify.
 
-    apply f_equal2; [|reflexivity].
-    apply Nnat.N2Nat.inj_iff.
-    match goal with
-    | |- context [@while_loop _ ?iter ?cond ?st ?body] =>
-      rewrite <- (while_loop_end_exact iter body
-                                       (fun '(_,_,_,failed,_) => negb failed)
-                                       (fun '(_,begin,_,_,_) => N.to_nat begin)
-                                       (N.to_nat end_)) with (start:=st);
-        simplify
-    end.
+      { (* table_index = mm_index begin root_level *)
+        rewrite mm_index_start_of_next_block; reflexivity. }
+      { (* start_begin <= begin *)
+        match goal with
+          |- (_ <= mm_start_of_next_block ?x _)%N => transitivity x; [solver|]
+        end.
+        admit. (* TODO : factor out mm_start_of_next_block proof saying it obeys le *) }
+      { (* begin <= mm_level_end end_ root_level *)
+        admit. (* TODO: factor out a lemma about mm_start_of_next_block saying that it won't skip over the level end *) }
+      { (* pointers_ok s ppool *)
+        admit. (* TODO : factor out mm_map_level proof *) }
+      { (* is_begin_or_block_start start_begin begin  *)
+        cbv [is_begin_or_block_start].
+        right. apply mm_start_of_next_block_is_start. }
+      { (* index sequences don't change *)
+        apply Forall_forall; intros.
+        apply Forall_forall; intros.
+        admit.
+        (* TODO: factor out a lemma about mm_map_level saying that reassigning the pointer is OK wrt existing pointer index sequences
+           (reasoning: mm_map_level is not going to add any new
+           pointers to the state unless it gets them from mpool, which
+           won't give out stuff that's already there -- probably will
+           require precondition saying mpool doesn't have any pointers
+           that are referenced from any roots) *) }
+      { (* represents step *)
+        pose proof (mm_level_end_root_eq root_level ltac:(assumption) begin end_).
 
-    {
-    repeat (f_equal;
-            try
-              (apply while_loop_proper_cond;
-               repeat match goal with
-                      | _ => progress basics
-                      | p : _ * _ |- _ => destruct p
-                      | _ => apply N.to_nat_ltb
-                      | _ => solver
-                      end)). }
-    6 : {
-    rewrite while_loop_proper_cond with
-        (cond':=fun '(_,begin,_,_,_) => N.to_nat begin <? N.to_nat end_) in * by
-        repeat match goal with
-               | _ => progress basics
-               | p : _ * _ |- _ => destruct p
-               | _ => apply N.to_nat_ltb
-               | _ => solver
-               end.
-    solver. }
+        (* find the current [begin] and assert that its index is in between the
+           start and end addresses' indices *)
+        match goal with
+        | H : is_begin_or_block_start _ ?x _ |- _ =>
+          assert (mm_index begin root_level <= mm_index x root_level)
+            by (apply mm_index_le_mono; solver);
+          assert (mm_index x root_level <= mm_index end_ root_level)
+            by (apply mm_index_le_mono; [ solver | ];
+                erewrite mm_level_end_root_eq by auto;
+                apply mm_level_end_le)
+        end.
 
-    { cbv [break continue] in *; solver. }
-    { admit. (* TODO: assume this about mm_start_of_next_block, that its results are > input *) }
-    { admit. (* TODO: assume this about mm_start_of_next_block, that it won't skip pages if end_ is aligned *) }
-    { apply Nat.leb_le. rewrite Nat.leb_compare.
-      rewrite <-Nnat.N2Nat.inj_compare. break_match; solver. }
-    { rewrite Nnat.N2Nat.inj_sub; solver. }
+        (* pull out S so we can rewrite about [firstn] *)
+        rewrite Nat.sub_succ_l by solver.
+
+        rewrite firstn_snoc with (d:=Datatypes.null_pointer)
+          by (autorewrite with push_length; lia).
+        rewrite fold_left_app.
+        cbn [fold_left].
+        cbv [nth_default_oobe Assumptions.Datatypes.ptable_pointer_oobe oob_value].
+
+        (* fix up the nth_default thing *)
+        rewrite nth_default_skipn.
+        rewrite nth_default_firstn_low by solver.
+        match goal with |- context [?a - ?b + ?b] =>
+                        replace (a - b + b) with a by omega end.
+
+        (* swap out starting concrete state for current one *)
+        match goal with
+          |- represents (abstract_reassign_pointer _ ?conc _ _ _ _) (reassign_pointer ?c _ _) =>
+          rewrite abstract_reassign_pointer_change_concrete with (conc':=c)
+            by
+              repeat match goal with
+                     | H : Forall _ _ |- _ => rewrite Forall_forall in H; apply H
+                     | _ => apply In_nth_default_skipn_firstn
+                     | _ => solver
+                     end
+        end.
+
+        apply reassign_pointer_represents with (level := root_level - 1).
+        { assumption. }
+        { apply has_uniform_attrs_reassign_pointer;
+            [ solve [auto using mm_map_level_noncircular] | ].
+          match goal with
+          | H : is_begin_or_block_start _ _ _ |- _ =>
+            destruct H as [H | H];
+              [ | replace root_level with (S (root_level - 1)) in H by solver ]
+          end.
+          { (* begin = n *)
+            simplify.
+            auto using mm_map_level_table_attrs. }
+          { eapply has_uniform_attrs_expand_range; try eassumption; [ ].
+            apply mm_map_level_table_attrs. } } } }
+    { (* invariant holds at start *)
+      right. simplify.
+      {  lia. }
+      {  erewrite mm_level_end_root_eq by eauto; apply mm_level_end_le. }
+      {  cbv [is_begin_or_block_start]; solver. }
+      { apply Forall_forall; intros.
+        apply Forall_forall; intros.
+        reflexivity. }
+      { rewrite Nat.sub_diag.
+        autorewrite with push_firstn push_fold_left.
+        auto. } }
+    { (* invariant implies correctness *)
+      repeat inversion_bool; simplify; [ ].
+      match goal with
+      | |- context [@while_loop _ ?iter ?cond ?st ?body] =>
+          assert (cond (@while_loop _ iter cond st body) = false);
+            [ apply (while_loop_completed iter cond body
+                                          (fun '(_,_,_,failed,_) => negb failed)
+                                          (fun '(_,begin,_,_,_) => N.to_nat begin)
+                                          (N.to_nat end_))
+            | remember (@while_loop _ iter cond st body) as RET]
+      end.
+
+      (* get rid of all but 2 goals *)
+      all:simplify.
+      all:try apply N.to_nat_ltb.
+      all:try apply Bool.negb_true_iff.
+      all:simplify.
+      all:try solve [rewrite ?Nnat.N2Nat.inj_sub; solver].
+
+      { admit. (* TODO: assume this about mm_start_of_next_block, that its results are > input *) }
+      {
+        match goal with |- context [while_loop _ _ ?body] => remember body as F end.
+        match goal with
+        | H : represents (fold_left ?f ?ls ?a) ?x
+          |- represents (fold_left ?f ?ls2 ?a) ?x =>
+          assert (ls = ls2); [clear H | solver ]
+        end.
+        (* prove lists are equal (i.e. the table index gets to the end of the list) *)
+
+        remember (snd (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F)))) as IDX.
+        remember (snd (fst (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F))))) as BEGIN.
+        remember (fst (fst (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F))))) as CONC.
+        clear HeqBEGIN HeqCONC HeqIDX.
+
+        subst IDX.
+        
+        apply firstn_all2.
+        autorewrite with push_length.
+        rewrite Min.min_l by lia.
+        match goal with 
+        | H : (_ <? _)%N = false |- _ =>
+          apply N.ltb_ge in H;
+            apply mm_index_le_mono with (level:=root_level) in H; try solver
+        end.
+        assert (mm_index begin root_level <= mm_index end_ root_level) by admit.
+        apply Nat.sub_le_mono_r.
+        solver.
   Admitted.
 
   Lemma mm_ptable_identity_update_represents

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -129,55 +129,24 @@ Section Proofs.
      states *)
   Axiom TODO : @abstract_state paddr_t nat.
 
-
-  (* Need to figure out alignment situation!
-     - condition of while loop is [end <= begin]
-     - [end] is rounded *up* to the nearest page
-     - [mm_start_of_next_block]...what does it do? I think it gets the address of
-       the next table entry at the given level, as suggested by incrementation of
-       [table_index]
-        * it zeroes out all the bits below the provided block size, which is mm_entry_size level, so yes
-     
-     if [end] is not aligned to the entry size, then what will happen?
-        well, we'll eventually get to a point where [mm_index begin level = mm_index end level], but begin < end because begin is aligned
-        we'll do that reassignment and the range checks will keep things honest
-        then mm_index begin level = S (mm_index end level) and begin >= end; break
-
-     if [end] is aligned, then what will happen?
-        as soon as [mm_index begin level = mm_index end level], [begin = end] and we break
-
-     so...while_loop_end_exact is NOT the right thing, quite. We don't get
-     [begin = end_]; we get [begin >= end_] and
-     [mm_index begin level = if end_aligned_to_entry_size
-                             then mm_index end level
-                             else S (mm_index end level) ]
-     
-     if we know [mm_index begin level <= S (mm_index end level)], does that help?
-
-   *)
-
-  (* maybe we need some part of the concrete state to say where each
-  ptable_pointer is, exactly one location. They can be either in mpool
-  or somewhere in a page table, but this would enforce by construction
-  that they're not repeated... *)
   Axiom pointer_in_table :
     (Datatypes.ptable_pointer -> mm_page_table) ->
     Datatypes.ptable_pointer -> mm_page_table -> Prop.
-
 
   Definition deref_noncircular (c : concrete_state) : Prop :=
     forall ptr,
       ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr).
 
+  (* TODO : move *)
   Axiom mpool_contains : mpool -> Datatypes.ptable_pointer -> Prop.
 
+  (* TODO : is this the right approach? *)
   Definition pointers_ok (c : concrete_state) (ppool : mpool) : Prop :=
     deref_noncircular c
     /\ (forall ptr,
            mpool_contains ppool ptr <->
            (forall ptr2, ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr2))).
 
-  (* TODO : is this the right approach? *)
   Lemma mm_map_level_noncircular c begin end_ pa attrs ptr level flags ppool :
     pointers_ok c ppool ->
     let ret := mm_map_level
@@ -185,7 +154,35 @@ Section Proofs.
     let table := snd (fst (fst ret)) in
     ~ pointer_in_table (ptable_deref c) ptr table.
   Admitted. (* TODO *)
- 
+
+  (* TODO: needs preconditions *)
+  Lemma mm_map_level_pointers_ok c begin end_ pa attrs ptr level flags ppool :
+    pointers_ok c ppool ->
+    let ret := mm_map_level
+                 c begin end_ pa attrs (ptable_deref c ptr) level flags ppool in
+    let table := snd (fst (fst ret)) in
+    let ppool' := snd ret in
+    pointers_ok (reassign_pointer c ptr table) ppool'.
+  Admitted. (* TODO *)
+
+  (* TODO: might want a nicer reasoning framework for this *)
+  (* mm_map_level doesn't alter the global locations of any pointers above the
+     level at which it operates *)
+  Lemma mm_map_level_index_sequences
+        c begin end_ pa attrs root_ptr ptr level flags ppool :
+    pointers_ok c ppool ->
+    let ret := mm_map_level
+                 c begin end_ pa attrs (ptable_deref c ptr) level flags ppool in
+    let table := snd (fst (fst ret)) in
+    In ptr (mm_page_table_from_pa root_ptr) ->
+    forall ptr' root_ptable,
+      In ptr' (mm_page_table_from_pa root_ptr) ->
+      In root_ptable (hafnium_root_ptable :: map vm_root_ptable vms) ->
+      index_sequences_to_pointer c.(ptable_deref) ptr' root_ptable =
+      index_sequences_to_pointer
+        (reassign_pointer c ptr table).(ptable_deref) ptr' root_ptable.
+  Admitted. (* TODO *)
+
   Definition is_start_of_block (a : ptable_addr_t) (level : nat) : Prop :=
     (a & (mm_entry_size level - 1))%N = 0.
 
@@ -198,40 +195,11 @@ Section Proofs.
              (start_begin begin : ptable_addr_t) root_level : Prop :=
       (begin = start_begin \/ is_start_of_block begin root_level).
 
-  (* TODO: we're not actually using the starting concrete state all
-  the time; the concrete state has to change. But how exactly can we
-  encode that? *)
-  (* In reality, it shouldn't matter that the concrete state is
-  changing because we only care about the subset of it that leads to
-  the pointers we're changing, and those pointers should all be on the
-  same level and not be in each other's paths. Can we encode this by
-  passing in the index sequences to the pointer, perhaps, instead of
-  the entire concrete state? *)
-  (* Can we say each pointer has exactly one index sequence and they
-  don't affect each other's index sequences and then pass in an index
-  sequence to abstract_reassign_pointer instead of a concrete state
-  and a pointer? *)
-  (* Should we do away with ptable_pointer entirely? *)
-  (* what if, instead of ptable_pointer, we had something that
-  indicated position-from-root? Something like the index sequences? *)
-  (* the beauty of the current solution is that it *does* remap every
-  location exactly as happens in concrete state. But can we preserve
-  that beauty? Where exactly would we run into problems with allowing
-  for repeats of the same pointer? *)
-  (* well, somewhere we need to know that the concrete state doesn't
-  change stuff in random other places...we *need* the property that
-  ptable_pointers don't repeat themselves *)
-  (* in this case, that reasoning would look like:
-     - every ptable_pointer has exactly one index_sequence from exactly one table (reassign_pointer preserves that property because mm_map_level output fits certain conditions)
-     - none of the reassignments we do will change each other's index sequence, because they can't change anything shorter than themselves
-     - if the index_sequence for the pointer passed into abstract_reassign_pointer hasn't changed, we can switch out concrete states
-   *)
   Definition mm_map_root_loop_invariant
              start_abst start_conc t_ptrs start_begin end_ attrs root_level
              (state : concrete_state * ptable_addr_t * size_t * bool * mpool)
     : Prop :=
     let '(s, begin, table_index, failed, ppool) := state in
-    let index := table_index - mm_index start_begin root_level in
     let end_index := mm_index end_ root_level in
     (failed = true \/
      (table_index = mm_index begin root_level
@@ -253,7 +221,7 @@ Section Proofs.
                (fun abst t_ptr =>
                   abstract_reassign_pointer
                     abst start_conc t_ptr attrs start_begin end_)
-               (firstn index t_ptrs)
+               (firstn table_index t_ptrs)
                start_abst)
             s))).
 
@@ -319,6 +287,14 @@ Section Proofs.
        precondition in terms of mm_level_end. *)
   Admitted.
 
+  Lemma mm_start_of_next_block_lt a block_size :
+    (a < mm_start_of_next_block a block_size)%N.
+  Admitted. (* TODO *)
+
+  Lemma mm_start_of_next_block_level_end a level :
+    (mm_start_of_next_block a (mm_entry_size level) <= mm_level_end a level)%N.
+  Admitted. (* TODO *)
+
   Lemma mm_index_le_mono a b level :
     (a <= b)%N ->
     (b <= mm_level_end a level)%N ->
@@ -352,18 +328,6 @@ Section Proofs.
   Admitted. (* TODO *)
 
   (* TODO : move *)
-  Lemma fold_left_ext {A B} (f g : B -> A -> B) b ls :
-    (forall a b, In b ls -> f a b = g a b) ->
-    fold_left f ls b = fold_left g ls b.
-  Admitted. (* TODO *)
-
-  (* TODO : move *)
-  Lemma fold_left_nil {A B} (f : B -> A -> B) b :
-    fold_left f nil b = b.
-  Proof. reflexivity. Qed.
-  Hint Rewrite @fold_left_nil : push_fold_left.
-
-  (* TODO : move *)
   Lemma Forall_map {A B} (P : B -> Prop) (f : A -> B) ls :
     Forall P (map f ls) -> Forall (fun a => P (f a)) ls.
   Admitted. (* TODO *)
@@ -393,17 +357,6 @@ Section Proofs.
            end.
   Qed.
 
-  (* TODO : move *)
-  Lemma nth_default_skipn {A} (d:A) i j ls :
-    nth_default d (skipn i ls) j = nth_default d ls (j + i).
-  Admitted. (* TODO *)
-
-  (* TODO : move *)
-  Lemma nth_default_firstn_low {A} (d:A) i j ls :
-    j < i ->
-    nth_default d (firstn i ls) j = nth_default d ls j.
-  Admitted. (* TODO *)
-
   Lemma mm_level_end_le a level : (a <= mm_level_end a level)%N.
   Admitted. (* TODO *)
 
@@ -420,21 +373,9 @@ Section Proofs.
   Admitted. (* TODO *)
 
   (* TODO : move *)
-  Lemma In_nth_default_firstn {A} (d:A) i j ls :
-    i < j ->
-    In (nth_default d ls i) (firstn j ls).
-  Admitted. (* TODO *)
-
-  (* TODO : move *)
-  Lemma In_nth_default_skipn {A} (d:A) i j ls :
-    j <= i ->
-    In (nth_default d ls i) (skipn j ls).
-  Admitted. (* TODO *)
-
-  (* TODO : move *)
-  Lemma In_nth_default_skipn_firstn {A} (d:A) i j k ls :
-    j <= i < k->
-    In (nth_default d ls i) (skipn j (firstn k ls)).
+  Lemma In_nth_default {A} (d : A) ls i :
+    i < length ls ->
+    In (nth_default d ls i) ls.
   Admitted. (* TODO *)
 
   (* TODO : move *)
@@ -462,18 +403,70 @@ Section Proofs.
   (* TODO : move *)
   (* TODO : probably will need preconditions about pointers being noncircular *)
   Lemma abstract_reassign_pointer_root abst conc root_ptr attrs begin end_ :
-    represents
+    abstract_state_equiv
       (fold_left
          (fun abst t_ptr =>
             abstract_reassign_pointer abst conc t_ptr attrs begin end_)
          (mm_page_table_from_pa root_ptr)
          abst)
-      conc ->
-    represents
-      (abstract_reassign_pointer abst conc (ptable_pointer_from_address root_ptr)
-                                 attrs begin end_)
-      conc.
+      (abstract_reassign_pointer abst conc
+                                 (ptable_pointer_from_address root_ptr)
+                                 attrs begin end_).
   Admitted. (* TODO *)
+
+  (* if all the pointers provided are out of range of the given addresses, the
+     abstract state doesn't change *)
+  (* TODO: needs some kind of precondition to say that the table is indeed at the right level *)
+  Lemma abstract_reassign_pointer_low
+        abst conc root_ptr level attrs begin end_ :
+    let pointers := mm_page_table_from_pa root_ptr in
+    abstract_state_equiv
+      abst
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         (firstn (mm_index begin level) pointers)
+         abst).
+  Admitted.
+
+  (* we can expand the range to include pointers that are out of range *)
+  (* TODO: needs some kind of precondition to say that the table is indeed at the right level *)
+  Lemma abstract_reassign_pointer_high
+        abst conc root_ptr level attrs begin end_ i :
+    mm_index (end_ - 1) level < i ->
+    let pointers := mm_page_table_from_pa root_ptr in
+    abstract_state_equiv
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         (firstn i pointers)
+         abst)
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         pointers
+         abst).
+  Admitted.
+
+  Lemma mm_index_lt_mono_start (a b : ptable_addr_t) (level : nat) :
+    is_start_of_block a level ->
+    (b < a)%N ->
+    mm_index b level < mm_index a level.
+  Admitted. (* TODO *)
+
+  (* TODO : move *)
+  Lemma N_to_nat_lt_iff x y : N.to_nat x < N.to_nat y <-> (x < y)%N.
+  Admitted. (* TODO *)
+
+  (* makes proof state more readable *)
+  Local Ltac remember_while_loop :=
+    let RET := fresh "RET" in
+    match goal with
+    | |- context [@while_loop _ ?iter ?cond ?start ?body] =>
+      remember (@while_loop _ iter cond start body) as RET
+    | H : context [@while_loop _ ?iter ?cond ?start ?body] |- _ =>
+      remember (@while_loop _ iter cond start body) as RET
+    end.
 
   (* TODO:
      This proof says only that if success = true and commit = true
@@ -482,10 +475,6 @@ Section Proofs.
      unchanged, and another saying that if success = true and commit =
      false, then success = true when the function is run again on the
      (unchanged) output state. *)
-  (* mm_level_end with level=root_level should be the end of the *root* ptable -- that means
-     mm_level_end begin root_level = mm_level_end end_ root_level *)
-  (* since abstract_reassign_pointer doesn't do anything if the
-  addresses given are out of range, we can reassign from root *)
   Lemma mm_map_root_represents_commit
         (conc : concrete_state)
         t begin end_ attrs root_level flags ppool :
@@ -497,12 +486,10 @@ Section Proofs.
     let success := fst (fst ret) in
     let begin_index := mm_index begin root_level in
     let end_index := mm_index end_ root_level in
-    let t_ptrs :=
-        skipn begin_index
-              (firstn (S end_index) (mm_page_table_from_pa t.(root))) in
     success = true ->
     ((flags & MM_FLAG_COMMIT) != 0)%N = true ->
-    (begin <= end_)%N ->
+    (* TODO : maybe can remove the begin <= end precondition; if it's not true the loop just doesn't happen *)
+    (begin < end_)%N ->
     (* before calling mm_map_root, we have rounded end_ up to the nearest page,
        and we have capped it to not go beyond the end of the table *)
     end_index < length (mm_page_table_from_pa t.(root)) ->
@@ -512,11 +499,8 @@ Section Proofs.
     pointers_ok conc ppool ->
     forall abst,
       represents abst conc ->
-      represents (fold_left
-                    (fun abst t_ptr =>
-                       abstract_reassign_pointer
-                         abst conc t_ptr attrs begin end_)
-                    t_ptrs abst)
+      represents (abstract_reassign_pointer
+                         abst conc (ptable_pointer_from_address t.(root)) attrs begin end_)
                  conc'.
   Proof.
     cbv zeta. cbv [mm_map_root].
@@ -524,11 +508,11 @@ Section Proofs.
 
     pose proof (root_pos root_level ltac:(auto)). 
 
+    apply (represents_proper_abstr _ _ _ ltac:(apply abstract_reassign_pointer_root)).
+
     let begin_index := constr:(mm_index begin root_level) in
     let end_index := constr:(mm_index end_ root_level) in
-    let t_ptrs := constr:(skipn begin_index
-                                (firstn (S end_index)
-                                        (mm_page_table_from_pa t.(root)))) in
+    let t_ptrs := constr:(mm_page_table_from_pa t.(root)) in
     match goal with
     | |- context [@while_loop _ ?iter ?cond ?start ?body] =>
       assert (mm_map_root_loop_invariant
@@ -544,6 +528,19 @@ Section Proofs.
       simplify; repeat inversion_bool; [ ].
       right; rewrite !mm_map_level_represents.
 
+      (* find the current [begin] and assert that its index is in between the
+           start and end addresses' indices *)
+      pose proof (mm_level_end_root_eq root_level ltac:(assumption) begin end_).
+      match goal with
+      | H : is_begin_or_block_start _ ?x _ |- _ =>
+        assert (mm_index begin root_level <= mm_index x root_level)
+          by (apply mm_index_le_mono; solver);
+          assert (mm_index x root_level <= mm_index end_ root_level)
+          by (apply mm_index_le_mono; [ solver | ];
+              erewrite mm_level_end_root_eq by auto;
+              apply mm_level_end_le)
+      end.
+
       (* split into the invariant clauses *)
       simplify.
 
@@ -553,53 +550,34 @@ Section Proofs.
         match goal with
           |- (_ <= mm_start_of_next_block ?x _)%N => transitivity x; [solver|]
         end.
-        admit. (* TODO : factor out mm_start_of_next_block proof saying it obeys le *) }
+        apply N.lt_le_incl.
+        apply mm_start_of_next_block_lt. }
       { (* begin <= mm_level_end end_ root_level *)
-        admit. (* TODO: factor out a lemma about mm_start_of_next_block saying that it won't skip over the level end *) }
+        erewrite mm_level_end_root_eq by eauto.
+        apply mm_start_of_next_block_level_end. }
       { (* pointers_ok s ppool *)
-        admit. (* TODO : factor out mm_map_level proof *) }
+        apply mm_map_level_pointers_ok.
+        auto. }
       { (* is_begin_or_block_start start_begin begin  *)
         cbv [is_begin_or_block_start].
         right. apply mm_start_of_next_block_is_start. }
       { (* index sequences don't change *)
         apply Forall_forall; intros.
         apply Forall_forall; intros.
-        admit.
-        (* TODO: factor out a lemma about mm_map_level saying that reassigning the pointer is OK wrt existing pointer index sequences
-           (reasoning: mm_map_level is not going to add any new
-           pointers to the state unless it gets them from mpool, which
-           won't give out stuff that's already there -- probably will
-           require precondition saying mpool doesn't have any pointers
-           that are referenced from any roots) *) }
+        repeat match goal with
+               | H : Forall _ _ |- _ =>
+                 rewrite Forall_forall in H; specialize (H _ ltac:(eassumption));
+                   try rewrite H
+               end.
+        eapply mm_map_level_index_sequences; eauto; [ ].
+        apply In_nth_default; solver. }
       { (* represents step *)
-        pose proof (mm_level_end_root_eq root_level ltac:(assumption) begin end_).
-
-        (* find the current [begin] and assert that its index is in between the
-           start and end addresses' indices *)
-        match goal with
-        | H : is_begin_or_block_start _ ?x _ |- _ =>
-          assert (mm_index begin root_level <= mm_index x root_level)
-            by (apply mm_index_le_mono; solver);
-          assert (mm_index x root_level <= mm_index end_ root_level)
-            by (apply mm_index_le_mono; [ solver | ];
-                erewrite mm_level_end_root_eq by auto;
-                apply mm_level_end_le)
-        end.
-
-        (* pull out S so we can rewrite about [firstn] *)
-        rewrite Nat.sub_succ_l by solver.
 
         rewrite firstn_snoc with (d:=Datatypes.null_pointer)
           by (autorewrite with push_length; lia).
         rewrite fold_left_app.
         cbn [fold_left].
         cbv [nth_default_oobe Assumptions.Datatypes.ptable_pointer_oobe oob_value].
-
-        (* fix up the nth_default thing *)
-        rewrite nth_default_skipn.
-        rewrite nth_default_firstn_low by solver.
-        match goal with |- context [?a - ?b + ?b] =>
-                        replace (a - b + b) with a by omega end.
 
         (* swap out starting concrete state for current one *)
         match goal with
@@ -608,7 +586,7 @@ Section Proofs.
             by
               repeat match goal with
                      | H : Forall _ _ |- _ => rewrite Forall_forall in H; apply H
-                     | _ => apply In_nth_default_skipn_firstn
+                     | _ => apply In_nth_default
                      | _ => solver
                      end
         end.
@@ -629,15 +607,13 @@ Section Proofs.
             apply mm_map_level_table_attrs. } } } }
     { (* invariant holds at start *)
       right. simplify.
-      {  lia. }
       {  erewrite mm_level_end_root_eq by eauto; apply mm_level_end_le. }
       {  cbv [is_begin_or_block_start]; solver. }
       { apply Forall_forall; intros.
         apply Forall_forall; intros.
         reflexivity. }
-      { rewrite Nat.sub_diag.
-        autorewrite with push_firstn push_fold_left.
-        auto. } }
+      { eapply represents_proper_abstr; [|solver].
+        apply abstract_reassign_pointer_low. } }
     { (* invariant implies correctness *)
       repeat inversion_bool; simplify; [ ].
       match goal with
@@ -650,6 +626,10 @@ Section Proofs.
             | remember (@while_loop _ iter cond st body) as RET]
       end.
 
+      (* speeds up and simplifies proofs to forget that the thing we're talking about is a loop *)
+      all:remember_while_loop.
+      all:clear HeqRET.
+
       (* get rid of all but 2 goals *)
       all:simplify.
       all:try apply N.to_nat_ltb.
@@ -657,35 +637,19 @@ Section Proofs.
       all:simplify.
       all:try solve [rewrite ?Nnat.N2Nat.inj_sub; solver].
 
-      { admit. (* TODO: assume this about mm_start_of_next_block, that its results are > input *) }
-      {
-        match goal with |- context [while_loop _ _ ?body] => remember body as F end.
-        match goal with
-        | H : represents (fold_left ?f ?ls ?a) ?x
-          |- represents (fold_left ?f ?ls2 ?a) ?x =>
-          assert (ls = ls2); [clear H | solver ]
+      { apply N_to_nat_lt_iff.
+        apply mm_start_of_next_block_lt. } 
+      { match goal with
+        | H : represents ?x ?c |- represents ?y ?c =>
+          apply (represents_proper_abstr x y c); [|solver]
         end.
-        (* prove lists are equal (i.e. the table index gets to the end of the list) *)
+        pose proof abstract_reassign_pointer_high.
+        apply abstract_reassign_pointer_high with (level:=root_level).
 
-        remember (snd (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F)))) as IDX.
-        remember (snd (fst (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F))))) as BEGIN.
-        remember (fst (fst (fst (fst (while_loop (fun '(_, begin0, _, _, _) => (begin0 <? end_)%N) (conc, begin, mm_index begin root_level, false, ppool) F))))) as CONC.
-        clear HeqBEGIN HeqCONC HeqIDX.
-
-        subst IDX.
-        
-        apply firstn_all2.
-        autorewrite with push_length.
-        rewrite Min.min_l by lia.
-        match goal with 
-        | H : (_ <? _)%N = false |- _ =>
-          apply N.ltb_ge in H;
-            apply mm_index_le_mono with (level:=root_level) in H; try solver
-        end.
-        assert (mm_index begin root_level <= mm_index end_ root_level) by admit.
-        apply Nat.sub_le_mono_r.
-        solver.
-  Admitted.
+        repeat inversion_bool.
+        cbv [is_begin_or_block_start] in *.
+        apply mm_index_lt_mono_start; simplify. } }
+  Qed.
 
   Lemma mm_ptable_identity_update_represents
         (conc : concrete_state)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -233,10 +233,6 @@ Section Proofs.
       has_uniform_attrs conc.(ptable_deref) table (level - 1) attrs begin' end_.
   Admitted.
 
-  (* placeholder; later there will be actual expressions for the new abstract
-     states *)
-  Axiom TODO : @abstract_state paddr_t nat.
-
   Lemma mm_map_level_noncircular c begin end_ pa attrs ptr level flags ppool :
     pointers_ok c ppool ->
     let ret := mm_map_level
@@ -575,6 +571,10 @@ Section Proofs.
                | _ => solver
                end. }
   Qed.
+
+  (* placeholder; later there will be actual expressions for the new abstract
+     states *)
+  Axiom TODO : @abstract_state paddr_t nat.
 
   (*** Proofs about [mm_ptable_identity_update] ***)
 

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -1,5 +1,6 @@
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
 Require Import Coq.NArith.BinNat.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.Datatypes.
@@ -96,9 +97,9 @@ Section Proofs.
      state) *)
   Lemma mm_map_level_represents
         (conc : concrete_state)
-        t begin end_ attrs table level flags ppool :
+        begin end_ pa attrs table level flags ppool :
     (snd (fst (mm_map_level
-                 conc t begin end_ attrs table level flags ppool))) = conc.
+                 conc begin end_ pa attrs table level flags ppool))) = conc.
   Proof.
     autounfold; cbv [mm_map_level].
     repeat match goal with
@@ -110,19 +111,103 @@ Section Proofs.
            end.
   Qed.
 
+  Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level
+        flags ppool :
+    let ret :=
+        mm_map_level conc begin end_ pa attrs table level flags ppool in
+    let success := fst (fst (fst ret)) in
+    let table := snd (fst (fst ret)) in
+    let conc' := snd (fst ret) in
+    let ppool' := snd ret in
+    let begin : nat := mm_index begin level in
+    let end_ : nat := mm_index end_ level in
+    has_uniform_attrs conc'.(ptable_deref) table level attrs begin end_.
+  Admitted.
+
   (* placeholder; later there will be actual expressions for the new abstract
      states *)
   Axiom TODO : @abstract_state paddr_t nat.
 
+  (* TODO: we know that all the mm_map_level steps succeed because we
+  know that the whole thing succeeds. But how do we use that in the
+  invariant? *)
   Definition mm_map_root_loop_invariant
-             start_abst start_conc t_ptr start_begin attrs root_level
+             start_abst start_conc t_ptrs start_begin attrs root_level
              (state : concrete_state * ptable_addr_t * size_t * bool * mpool)
     : Prop :=
     let '(s, begin, table_index, failed, ppool) := state in
     let index := mm_index begin root_level in
-    represents
-      (abstract_reassign_pointer start_abst start_conc t_ptr attrs start_begin index)
-      s.
+    table_index = index /\
+    (failed = true \/
+     represents
+       (fold_right
+          (fun t_ptr abst =>
+             abstract_reassign_pointer abst start_conc t_ptr attrs start_begin index)
+          start_abst
+          (firstn table_index t_ptrs))
+       s).
+
+  (* TODO: move *)
+  Lemma N_lnot_0_r a : N.lnot a 0 = a.
+  Proof. destruct a; reflexivity. Qed.
+
+  (* TODO: move *)
+  Lemma N_div2_lnot a n : N.div2 (N.lnot a n) = N.lnot (N.div2 a) (N.pred n).
+  Admitted. (* TODO *)
+    
+  (* TODO: move *)
+  Lemma N_lnot_shiftr a n m : ((N.lnot a n >> m) = N.lnot (a >> m) (n - m))%N.
+  Proof.
+    rewrite <-(Nnat.N2Nat.id m).
+    induction (N.to_nat m).
+    { rewrite !N.shiftr_0_r.
+      rewrite N.sub_0_r. reflexivity. }
+    { rewrite Nnat.Nat2N.inj_succ.
+      rewrite !N.shiftr_succ_r.
+      rewrite N.sub_succ_r.
+      rewrite <-N_div2_lnot.
+      solver. }
+  Qed.
+
+  (* TODO: move *)
+  Lemma N_log2_add_shiftl_1 a b : (b <= N.log2 (a + (1 << b)))%N.
+  Admitted. (* TODO *)
+
+  (* TODO: include 0 < PAGE_BITS axiom *)
+  Lemma mm_start_of_next_block_shift a level :
+    (0 < PAGE_BITS)%N ->
+    (mm_start_of_next_block a (mm_entry_size level)
+                            >> (PAGE_BITS + level * PAGE_LEVEL_BITS))%N =
+    ((a >> (PAGE_BITS + level * PAGE_LEVEL_BITS)) + 1)%N.
+  Proof.
+    intros.
+    cbv [mm_start_of_next_block mm_entry_size].
+    rewrite !Nnat.N2Nat.id, N.shiftr_land, N_lnot_shiftr.
+    rewrite N.shiftr_eq_0 with (a:=((_ << _) - 1)%N) by
+        (rewrite N.sub_1_r, N.shiftl_1_l, N.log2_pred_pow2 by lia; lia).
+    rewrite N.lnot_0_l.
+    match goal with
+    | |- context [((_ + (_ << ?x)) >> ?x)%N] =>
+      pose proof (N_log2_add_shiftl_1 a x);
+        assert ((1 << x) <> 0)%N by (rewrite N.shiftl_eq_0_iff; lia)
+    end.
+    rewrite N.land_ones_low by (rewrite N.log2_shiftr, N.size_log2 by lia; lia).
+    rewrite !N.shiftr_div_pow2, !N.shiftl_mul_pow2.
+    rewrite N.div_add by (apply N.pow_nonzero; lia).
+    lia.
+  Qed.
+
+  Lemma mm_index_start_of_next_block a level :
+    mm_index (mm_start_of_next_block a (mm_entry_size level)) level
+    = S (mm_index a level).
+  Proof.
+    cbv [mm_index].
+    rewrite mm_start_of_next_block_shift.
+    remember ((1 << PAGE_LEVEL_BITS) - 1)%N as mask.
+    remember (PAGE_BITS + level * PAGE_LEVEL_BITS)%N as B.
+    (* TODO: won't be *hard*, but will be annoying. Will likely require a
+       precondition in terms of mm_level_end. *)
+  Admitted.
 
   (* TODO:
      This proof says only that if success = true and commit = true
@@ -140,32 +225,54 @@ Section Proofs.
     let ppool' := snd ret in
     let conc' := snd (fst ret) in
     let success := fst (fst ret) in
-    let t_ptr := ptable_pointer_from_address t.(root) in
+    let t_ptrs := mm_page_table_from_pa t.(root) in
     let begin_index := mm_index begin root_level in
     let end_index := mm_index end_ root_level in
     success = true ->
     ((flags & MM_FLAG_COMMIT) != 0)%N = true ->
     (begin <= end_)%N ->
+    end_index < length t_ptrs ->
     forall abst,
       represents abst conc ->
-      represents (abstract_reassign_pointer
-                    abst conc t_ptr attrs begin_index end_index) conc'.
+      represents (fold_right
+                    (fun t_ptr abst =>
+                       abstract_reassign_pointer
+                         abst conc t_ptr attrs begin_index end_index)
+                    abst t_ptrs)
+                 conc'.
   Proof.
     cbv zeta. cbv [mm_map_root].
     simplify.
 
-    let t_ptr := constr:(ptable_pointer_from_address t.(root)) in
+    let t_ptrs := constr:(mm_page_table_from_pa t.(root)) in
     let start_begin := constr:(mm_index begin root_level) in
     match goal with
     | |- context [@while_loop _ ?iter ?cond ?start ?body] =>
       assert (mm_map_root_loop_invariant
-                abst conc t_ptr start_begin attrs root_level
+                abst conc t_ptrs start_begin attrs root_level
                 (@while_loop _ iter cond start body));
-        [ apply while_loop_invariant | ];
-        cbv [mm_map_root_loop_invariant] in *; simplify
+        [ apply while_loop_invariant | ]
+    end;
+      cbv [mm_map_root_loop_invariant] in *; simplify;
+        repeat inversion_bool;
+        rewrite ?mm_map_level_represents.
+    { rewrite mm_index_start_of_next_block; reflexivity. }
+    { rewrite mm_index_start_of_next_block; reflexivity. }
+    { right.
+      cbn [firstn fold_right].
+      rewrite ?mm_map_level_represents.
+        cbv [mm_map_root_loop_invariant] in *; simplify.
+        right.
+          rewrite ?mm_map_level_represents
     end.
-    3:admit. (* TODO: proof that if begin and end are the same then has_uniform_attrs is trivially true *)
-    all:rewrite ?mm_map_level_represents.
+    Check while_loop_invariant.
+    { (* TODO: in this case, the map_level step failed, so we can't have returned success. *)
+      
+      Check reassign_pointer_represents.
+      Print mm_page_table_from_pa.
+      Check ptable_pointer_from_address.
+      SearchAbout s.
+    3:rewrite abstract_reassign_pointer_trivial; solver.
     1-2: admit. (* mm_map_level layer *)
 
     match goal with

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -74,7 +74,7 @@ Section Proofs.
            match get_entry t i with
            | Some pte =>
              if arch_mm_pte_is_table pte lvl
-             then 
+             then
                let next_t_ptr :=
                    ptable_pointer_from_address (arch_mm_table_from_pte pte lvl) in
                if ptable_pointer_eq_dec ptr next_t_ptr

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -56,17 +56,58 @@ Section Proofs.
            end.
   Qed.
 
-  (* given a sequence of page table indices, says whether the address is found
-     under the same sequence of page table indexing *)
-  Definition is_under_path (indices : list nat) (addr : uintpaddr_t) : bool :=
-    forallb
-      (fun '(lvl, i) => get_index lvl addr =? i)
-      (combine (seq 0 4) indices).
+  Definition all_root_ptables : list mm_ptable :=
+    hafnium_ptable :: map vm_ptable vms.
+
+  Definition all_root_ptable_pointers : list ptable_pointer :=
+    hafnium_root_tables ++ flat_map vm_root_tables vms.
+
+  Fixpoint pointer_in_table'
+             (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
+             (t : mm_page_table) (lvls_to_go : nat) : Prop :=
+    match lvls_to_go with
+    | 0 => False
+    | S lvls_to_go' =>
+      let lvl := 4 - lvls_to_go in
+      Exists
+        (fun i =>
+           match get_entry t i with
+           | Some pte =>
+             if arch_mm_pte_is_table pte lvl
+             then 
+               let next_t_ptr :=
+                   ptable_pointer_from_address (arch_mm_table_from_pte pte lvl) in
+               if ptable_pointer_eq_dec ptr next_t_ptr
+               then True
+               else pointer_in_table' deref ptr (deref next_t_ptr) lvls_to_go'
+             else False
+           | None => False
+           end)
+        (seq 0 MM_PTE_PER_PAGE)
+    end.
+
+  Definition pointer_in_table
+             (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
+             (t : mm_page_table) : Prop :=
+    Forall (pointer_in_table' deref ptr t) (seq 0 4).
+
+  Definition deref_noncircular (c : concrete_state) : Prop :=
+    forall ptr,
+      ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr).
+
+  (* TODO : It's not clear that this definition is the correct approach. Consider
+     other ways to keep track of the fact that page tables don't have circular
+     references and don't use any locations in the freelist. *)
+  Definition pointers_ok (c : concrete_state) (ppool : mpool) : Prop :=
+    deref_noncircular c
+    /\ (forall ptr,
+           mpool_contains ppool ptr <->
+           (forall ptr2, ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr2))).
 
   (* We haven't formalized anywhere that pointers don't repeat, so we return a
      list of all locations where the provided pointer exists even though we
      expect there is only one. *)
-  Fixpoint index_sequences_to_pointer' (ptable_deref : ptable_pointer -> mm_page_table)
+  Fixpoint index_sequences_to_pointer'' (ptable_deref : ptable_pointer -> mm_page_table)
            (ptr : ptable_pointer) (root : ptable_pointer) (lvls_to_go : nat)
     : list (list nat) :=
     match lvls_to_go with
@@ -88,21 +129,30 @@ Section Proofs.
                        (arch_mm_table_from_pte pte lvl) in
                  map
                    (cons index)
-                   (index_sequences_to_pointer'
+                   (index_sequences_to_pointer''
                       ptable_deref ptr next_root lvls_to_go')
                else nil
              | None => nil
              end)
           (seq 0 MM_PTE_PER_PAGE)
     end.
+  Fixpoint index_sequences_to_pointer'
+           (ptable_deref : ptable_pointer -> mm_page_table)
+           (ptr : ptable_pointer) (root_index : nat)
+           (root_ptrs : list ptable_pointer) : list (list nat) :=
+    match root_ptrs with
+    | nil => nil
+    | cons root_ptr root_ptrs' =>
+      (map (cons root_index)
+           (index_sequences_to_pointer'' ptable_deref ptr root_ptr 4))
+        ++
+        index_sequences_to_pointer' ptable_deref ptr (S root_index) root_ptrs'
+    end.
   Definition index_sequences_to_pointer
-             (ptable_deref : ptable_pointer -> mm_page_table)
-             (ptr : ptable_pointer) (root : ptable_pointer) : list (list nat) :=
-    index_sequences_to_pointer' ptable_deref ptr root 4.
-
-  (* TODO : move *)
-  Axiom va_init : uintvaddr_t -> vaddr_t.
-  Axiom pa_from_va : vaddr_t -> paddr_t.
+           (ptable_deref : ptable_pointer -> mm_page_table)
+           (ptr : ptable_pointer) (root_ptable : mm_ptable) :=
+    index_sequences_to_pointer'
+      ptable_deref ptr 0 (ptr_from_va (va_from_pa root_ptable.(root))).
 
   Definition abstract_change_attrs (abst : abstract_state)
              (a : paddr_t) (e : entity_id) (owned valid : bool) :=
@@ -126,23 +176,34 @@ Section Proofs.
            else prev)
     |}.
 
+  (* given a sequence of page table indices, says whether the address is found
+     under the same sequence of page table indexing *)
+  Definition is_under_path (indices : list nat) (addr : uintpaddr_t) : bool :=
+    forallb
+      (fun '(lvl, i) => get_index lvl addr =? i)
+      (combine (seq 0 4) indices).
+
+  Definition addresses_under_pointer_in_range
+             (deref : ptable_pointer -> mm_page_table)
+             (ptr : ptable_pointer) (root_ptable : mm_ptable)
+             (begin end_ : uintvaddr_t) : list paddr_t :=
+    let vrange := map N.of_nat (seq (N.to_nat begin) (N.to_nat end_)) in
+    let prange := map (fun va => pa_from_va (va_init va)) vrange in
+    let paths := index_sequences_to_pointer deref ptr root_ptable in
+    filter
+      (fun a => existsb (fun p => is_under_path p (pa_addr a)) paths) prange.
+
   Definition abstract_reassign_pointer_for_entity
              (abst : abstract_state) (conc : concrete_state)
              (ptr : ptable_pointer) (owned valid : bool)
-             (e : entity_id) (root_ptable : ptable_pointer)
+             (e : entity_id) (root_ptable : mm_ptable)
              (begin end_ : uintvaddr_t) : abstract_state :=
-    let vrange := map N.of_nat (seq (N.to_nat begin) (N.to_nat end_)) in
-    let prange := map (fun va => pa_from_va (va_init va)) vrange in
-    let paths := index_sequences_to_pointer
-                   conc.(ptable_deref) ptr root_ptable in
-    let under_pointer : uintpaddr_t -> bool :=
-        fun addr =>
-          existsb (fun p => is_under_path p addr) paths in
     fold_right
       (fun pa abst =>
          abstract_change_attrs abst pa e owned valid)
       abst
-      (filter (fun pa => under_pointer (pa_addr pa)) prange).
+      (addresses_under_pointer_in_range
+         conc.(ptable_deref) ptr root_ptable begin end_).
 
   (* Update the abstract state to make everything under the given pointer have
      the provided new owned/valid bits. *)
@@ -161,14 +222,13 @@ Section Proofs.
     (* update the state with regard to Hafnium *)
     let abst :=
         abstract_reassign_pointer_for_entity
-          abst conc ptr s1_owned s1_valid (inr hid) hafnium_root_ptable
-          begin end_ in
+          abst conc ptr s1_owned s1_valid (inr hid) hafnium_ptable begin end_ in
 
     (* update the state with regard to each VM *)
     fold_right
       (fun (v : vm) (abst : abstract_state) =>
          abstract_reassign_pointer_for_entity
-           abst conc ptr s2_owned s2_valid (inl v.(vm_id)) (vm_root_ptable v)
+           abst conc ptr s2_owned s2_valid (inl v.(vm_id)) (vm_ptable v)
            begin end_)
       abst
       vms.
@@ -197,12 +257,104 @@ Section Proofs.
     cbv [vm_page_valid haf_page_valid vm_page_owned haf_page_owned].
     cbn [ptable_deref].
     basics; try solver.
-    (* 4 subgoals *)
+    (* TODO: 4 subgoals *)
   Admitted.
 
   Lemma abstract_reassign_pointer_trivial abst conc ptr attrs i :
     abstract_state_equiv (abstract_reassign_pointer abst conc ptr attrs i i)
                          abst.
+  Admitted. (* TODO *)
+
+  Lemma abstract_reassign_pointer_for_entity_change_concrete
+        abst conc conc' ptr owned valid e root_ptr begin end_ :
+    index_sequences_to_pointer conc.(ptable_deref) ptr root_ptr
+    = index_sequences_to_pointer conc'.(ptable_deref) ptr root_ptr ->
+    abstract_reassign_pointer_for_entity
+      abst conc ptr owned valid e root_ptr begin end_
+    = abstract_reassign_pointer_for_entity
+        abst conc' ptr owned valid e root_ptr begin end_.
+  Proof.
+    cbv beta iota delta [abstract_reassign_pointer_for_entity
+                           addresses_under_pointer_in_range].
+    intro Heq. rewrite Heq. reflexivity.
+  Qed.
+
+  Lemma abstract_reassign_pointer_change_concrete
+        abst conc conc' ptr attrs begin_index end_index :
+    Forall (fun root =>
+              index_sequences_to_pointer conc.(ptable_deref) ptr root
+              = index_sequences_to_pointer conc'.(ptable_deref) ptr root)
+           all_root_ptables ->
+    abstract_reassign_pointer abst conc ptr attrs begin_index end_index
+    = abstract_reassign_pointer abst conc' ptr attrs begin_index end_index.
+  Proof.
+    cbv [abstract_reassign_pointer all_root_ptables].
+    repeat match goal with
+           | _ => progress basics
+           | _ => progress invert_list_properties
+           | H : _ |- _ => apply Forall_map in H; rewrite Forall_forall in H
+           | _ =>
+             rewrite abstract_reassign_pointer_for_entity_change_concrete
+               with (conc':=conc') by eauto
+           | _ => apply fold_right_ext
+           | _ => solve
+                    [auto using
+                          abstract_reassign_pointer_for_entity_change_concrete]
+           end.
+  Qed.
+
+  (* has_uniform_attrs doesn't care if we reassign the pointer we started from *)
+  (* TODO : fill in preconditions *)
+  Lemma has_uniform_attrs_reassign_pointer c ptr new_table t level attrs begin end_:
+    ~ pointer_in_table (ptable_deref c) ptr t ->
+    has_uniform_attrs (ptable_deref c) t level attrs begin end_ ->
+    has_uniform_attrs
+      (ptable_deref (reassign_pointer c ptr new_table))
+      t level attrs begin end_.
+  Admitted. (* TODO *)
+
+  Definition no_addresses_in_range deref ptr begin end_ : Prop :=
+    Forall
+      (fun root_ptable =>
+         addresses_under_pointer_in_range deref ptr root_ptable begin end_ = nil)
+      all_root_ptables.
+
+  (* abstract_reassign_pointer is a no-op if the given tables don't have any
+     addresses in range *)
+  (* TODO: fill in preconditions; likely needs to know that the table is at the
+     right level *)
+  Lemma abstract_reassign_pointer_low
+        abst conc attrs begin end_ t_ptrs :
+    Forall
+      (fun ptr => no_addresses_in_range conc.(ptable_deref) ptr begin end_)
+      t_ptrs ->
+    abstract_state_equiv
+      abst
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         t_ptrs
+         abst).
   Admitted.
 
+  (* we can expand the range to include pointers that are out of range *)
+  (* TODO: fill in preconditions; likely needs to know that the table is at the
+     right level *)
+  Lemma abstract_reassign_pointer_high
+        abst conc attrs begin end_ i t_ptrs :
+    Forall
+      (fun ptr => no_addresses_in_range conc.(ptable_deref) ptr begin end_)
+      (skipn i t_ptrs) ->
+    abstract_state_equiv
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         (firstn i t_ptrs)
+         abst)
+      (fold_left
+         (fun abst t_ptr =>
+            abstract_reassign_pointer abst conc t_ptr attrs begin end_)
+         t_ptrs
+         abst).
+  Admitted.
 End Proofs.

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -260,9 +260,11 @@ Section Proofs.
     (* TODO: 4 subgoals *)
   Admitted.
 
-  Lemma abstract_reassign_pointer_trivial abst conc ptr attrs i :
-    abstract_state_equiv (abstract_reassign_pointer abst conc ptr attrs i i)
-                         abst.
+  Lemma abstract_reassign_pointer_trivial abst conc ptr attrs begin end_:
+    (end_ <= begin)%N ->
+    abstract_state_equiv
+      abst
+      (abstract_reassign_pointer abst conc ptr attrs begin end_).
   Admitted. (* TODO *)
 
   Lemma abstract_reassign_pointer_for_entity_change_concrete

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -31,6 +31,14 @@ Section Proofs.
     represents abst conc'.
   Admitted.
 
+  (* if two abstract states are equivalent and one represents a concrete state,
+     then the other also represents that concrete state. *)
+  Lemma represents_proper_abstr abst abst' conc :
+    abstract_state_equiv abst abst' ->
+    represents abst conc ->
+    represents abst' conc.
+  Admitted.
+
   (* if the new table is the same as the old, abstract state doesn't change *)
   Lemma reassign_pointer_noop_represents conc ptr t abst :
     conc.(ptable_deref) ptr = t ->
@@ -183,4 +191,10 @@ Section Proofs.
     basics; try solver.
     (* 4 subgoals *)
   Admitted.
+
+  Lemma abstract_reassign_pointer_trivial abst conc ptr attrs i :
+    abstract_state_equiv (abstract_reassign_pointer abst conc ptr attrs i i)
+                         abst.
+  Admitted.
+
 End Proofs.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -25,7 +25,7 @@ Module N.
 
   Lemma div2_lnot a n : N.div2 (N.lnot a n) = N.lnot (N.div2 a) (N.pred n).
   Admitted. (* TODO *)
-    
+
   Lemma lnot_shiftr a n m :
     N.shiftr (N.lnot a n) m = N.lnot (N.shiftr a m) (n - m).
   Proof.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -1,6 +1,7 @@
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.BinNat.
 Require Import Coq.NArith.Nnat.
+Require Import Hafnium.Util.Tactics.
 Local Open Scope N_scope.
 
 Module N.
@@ -18,4 +19,28 @@ Module N.
     rewrite <-N.compare_le_iff, <-Nat.compare_le_iff.
     rewrite N2Nat.inj_compare. reflexivity.
   Qed.
+
+  Lemma to_nat_lt_iff x y : (N.to_nat x < N.to_nat y)%nat <-> x < y.
+  Admitted. (* TODO *)
+
+  (* TODO: move *)
+  Lemma div2_lnot a n : N.div2 (N.lnot a n) = N.lnot (N.div2 a) (N.pred n).
+  Admitted. (* TODO *)
+    
+  Lemma lnot_shiftr a n m :
+    N.shiftr (N.lnot a n) m = N.lnot (N.shiftr a m) (n - m).
+  Proof.
+    rewrite <-(Nnat.N2Nat.id m).
+    induction (N.to_nat m).
+    { rewrite !N.shiftr_0_r.
+      rewrite N.sub_0_r. reflexivity. }
+    { rewrite Nnat.Nat2N.inj_succ.
+      rewrite !N.shiftr_succ_r.
+      rewrite N.sub_succ_r.
+      rewrite <-div2_lnot.
+      solver. }
+  Qed.
+
+  Lemma log2_add_shiftl_1 a b : b <= N.log2 (a + (N.shiftl 1 b)).
+  Admitted. (* TODO *)
 End N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -11,4 +11,11 @@ Module N.
     rewrite N2Nat.inj_compare.
     reflexivity.
   Qed.
+
+  Lemma to_nat_le_iff (x y : N) :
+    (N.to_nat x <= N.to_nat y)%nat <-> x <= y.
+  Proof.
+    rewrite <-N.compare_le_iff, <-Nat.compare_le_iff.
+    rewrite N2Nat.inj_compare. reflexivity.
+  Qed.
 End N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -23,7 +23,6 @@ Module N.
   Lemma to_nat_lt_iff x y : (N.to_nat x < N.to_nat y)%nat <-> x < y.
   Admitted. (* TODO *)
 
-  (* TODO: move *)
   Lemma div2_lnot a n : N.div2 (N.lnot a n) = N.lnot (N.div2 a) (N.pred n).
   Admitted. (* TODO *)
     

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -131,6 +131,11 @@ Section NthDefault.
              | _ => solve [auto using Lt.lt_n_S]
              end.
   Qed.
+
+  Lemma In_nth_default ls i :
+    i < length ls ->
+    In (nth_default d ls i) ls.
+  Admitted. (* TODO *)
 End NthDefault.
 Hint Rewrite @nth_default_nil @nth_default_cons : push_nth_default.
 
@@ -145,11 +150,21 @@ Section FoldRight.
     generalize dependent b; induction ls; intros;
       cbn [fold_right]; eauto.
   Qed.
+
+  Lemma fold_right_ext (f g : A -> B -> B) b ls :
+    (forall a b, In a ls -> f a b = g a b) ->
+    fold_right f b ls = fold_right g b ls.
+  Admitted. (* TODO *)
 End FoldRight.
 
 (* Proofs about [firstn] and [skipn] *)
 Section FirstnSkipn.
   Context {A : Type}.
+
+  Lemma firstn_snoc i ls d :
+    i < length ls ->
+    @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
+  Admitted. (* TODO *)
 
   Lemma in_firstn (a : A) ls : forall i, In a (firstn i ls) -> In a ls.
   Proof.
@@ -273,6 +288,10 @@ Section ListQualifiers.
            | |- Forall _ (_ ++ _) => apply Forall_app_iff
            | _ => crush_forall'
            end.
+
+  Lemma Forall_map {A B} (P : B -> Prop) (f : A -> B) ls :
+    Forall P (map f ls) -> Forall (fun a => P (f a)) ls.
+  Admitted. (* TODO *)
 
   (*** Some proofs about [ForallOrdPairs] ***)
 

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -190,11 +190,25 @@ Section FirstnSkipn.
              | _ => solver
              end.
   Qed.
+
+  Lemma skipn_length i : forall ls, length (@skipn A i ls) = length ls - i. 
+  Proof.
+    induction i; destruct ls; try reflexivity; [ ].
+    cbn [length skipn]. rewrite IHi. lia.
+  Qed.
+
+  Lemma skipn_all i : forall ls, length ls <= i -> @skipn A i ls = nil.
+  Proof.
+    induction i; destruct ls; cbn [length skipn]; try reflexivity; try lia; [ ].
+    intros; apply IHi; lia.
+  Qed.
 End FirstnSkipn.
 
 (* autorewrite databases for [firstn] and [skipn] *)
 Hint Rewrite @firstn_O @firstn_nil @firstn_cons : push_firstn.
 Hint Rewrite @skipn_nil @skipn_cons : push_skipn.
+Hint Rewrite @skipn_all using lia : push_skipn.
+Hint Rewrite @skipn_length : push_length.
 
 (* Proofs about setting the nth element of a list. *)
 Section SetNth.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -219,7 +219,7 @@ Section FirstnSkipn.
              end.
   Qed.
 
-  Lemma skipn_length i : forall ls, length (@skipn A i ls) = length ls - i. 
+  Lemma skipn_length i : forall ls, length (@skipn A i ls) = length ls - i.
   Proof.
     induction i; destruct ls; try reflexivity; [ ].
     cbn [length skipn]. rewrite IHi. lia.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -157,6 +157,19 @@ Section FoldRight.
   Admitted. (* TODO *)
 End FoldRight.
 
+Section FoldLeft.
+  Context {A B : Type}.
+
+  Lemma fold_left_invariant (P : B -> Prop) (f : B -> A -> B) b ls :
+    (forall a b, P b -> P (f b a)) ->
+    P b ->
+    P (fold_left f ls b).
+  Proof.
+    generalize dependent b; induction ls; intros;
+      cbn [fold_left]; eauto.
+  Qed.
+End FoldLeft.
+
 (* Proofs about [firstn] and [skipn] *)
 Section FirstnSkipn.
   Context {A : Type}.

--- a/coq-verification/src/Util/Loops.v
+++ b/coq-verification/src/Util/Loops.v
@@ -302,3 +302,11 @@ Proof.
          | _ => solver
          end.
 Qed.
+
+Lemma while_loop_noop {state} max_iterations cond start body :
+  cond start = false ->
+  @while_loop state max_iterations cond start body = start.
+Proof.
+  cbv [while_loop]; intros. rewrite while_loop'_step.
+  repeat break_match; solver.
+Qed.

--- a/coq-verification/src/Util/Tactics.v
+++ b/coq-verification/src/Util/Tactics.v
@@ -1,4 +1,5 @@
 Require Import Coq.omega.Omega.
+Require Import Coq.micromega.Lia.
 
 (* [inversion] with some cleanup afterwards *)
 Ltac invert H := inversion H; subst; clear H.
@@ -41,6 +42,7 @@ Ltac solver :=
   | _ => solve [eauto]
   | _ => congruence
   | _ => omega
+  | _ => lia
   end.
 
 Ltac inversion_bool :=

--- a/coq-verification/src/Util/Tactics.v
+++ b/coq-verification/src/Util/Tactics.v
@@ -57,4 +57,10 @@ Ltac inversion_bool :=
   | H : (_ <=? _) = false |- _ => apply Nat.leb_gt in H
   | H : (_ =? _) = true |- _ => apply Nat.eqb_eq in H
   | H : (_ =? _) = false |- _ => apply Nat.eqb_neq in H
+  | H : (_ <? _)%N = true |- _ => apply N.ltb_lt in H
+  | H : (_ <? _)%N = false |- _ => apply N.ltb_ge in H
+  | H : (_ <=? _)%N = true |- _ => apply N.leb_le in H
+  | H : (_ <=? _)%N = false |- _ => apply N.leb_gt in H
+  | H : (_ =? _)%N = true |- _ => apply N.eqb_eq in H
+  | H : (_ =? _)%N = false |- _ => apply N.eqb_neq in H
   end.


### PR DESCRIPTION
This (very large) PR encodes the core reasoning for the `mm_map_root` proof, now with all the facts about lower abstraction levels factored out into their own (as yet unproven) lemmas.

There's a lot of code here, and much of it is boilerplate. To inspect the core reasoning for `mm_map_root`, look at `mm_map_root_loop_invariant`, which states the invariant for the while loop that makes up the heart of the function. It has explanatory comments. I have also written comments inside the `mm_map_root` proof, so it should be possible to at least approximately follow the chain of reasoning.

The proof as written currently depends on 25 as-yet-unproven lemmas at different levels of abstraction:
- 5 lemmas about natural numbers and lists (easy)
- 6 lemmas about the relationship between concrete and abstract states (mixed difficulty)
- 10 proofs about low-level functions in `mm.c` like `mm_index` (not conceptually difficult but likely to be time-consuming due to complex bit-fiddling)
- 4 proofs about `mm_map_level` (potentially conceptually challenging, but less so than `mm_map_root` because it can reuse a lot of the same assumptions at the other levels of abstraction)

My current plan of attack for all of these is to first do the low-hanging fruit (the list and natural number lemmas and some of the low-level `mm.c` proofs). That way, I will eliminate a large number of these unproven dependencies without creating a bunch more. Next, I'll focus on anything I've marked as likely to be missing preconditions so I can start threading those preconditions through other proofs as early as possible. Once that's done, I will prove the rest by putting the hardest proofs first, so that I will run into trouble earlier rather than later.