### PR TITLE
Prove lemmas about low-level mm.c functions

### DIFF
--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -35,6 +35,7 @@ Qed.
 
 Lemma api_clear_memory_represents
       {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
+      {cp_ok : params_valid}
       (abst : abstract_state) (conc : concrete_state)
       begin end_ ppool :
   represents_valid abst conc ->

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -15,6 +15,7 @@
  *)
 
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Constants.
 Require Import Hafnium.Concrete.Assumptions.Datatypes.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 
@@ -70,3 +71,8 @@ Axiom arch_mm_is_block_allowed : level -> bool.
 Axiom arch_mm_block_from_pte : pte_t -> level -> paddr_t.
 
 Axiom arch_mm_combine_table_entry_attrs : attributes -> attributes -> attributes.
+
+
+(* Assumptions about the properties of arch/mm.c *)
+Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
+Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -60,5 +60,6 @@ Axiom mm_modes_distinct :
 Axiom mm_flags_distinct :
   NoDup [MM_FLAG_STAGE1_index; MM_FLAG_COMMIT_index].
 
-(* assume that PAGE_BITS is positive *)
+(* assume that PAGE_BITS and PAGE_LEVEL_BITS are positive *)
 Axiom PAGE_BITS_pos : 0 < PAGE_BITS.
+Axiom PAGE_LEVEL_BITS_pos : 0 < PAGE_LEVEL_BITS.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -379,7 +379,29 @@ Section Proofs.
     (a <= b)%N ->
     mm_level_end a level = mm_level_end b level ->
     mm_index a level <= mm_index b level.
-  Admitted. (* TODO *)
+  Proof.
+    rewrite <-mm_level_end_high_eq; intros.
+    rewrite mm_entry_size_step in *.
+    rewrite mm_entry_size_eq in *.
+    repeat progress rewrite ?Nnat.Nat2N.inj_mul, ?Nat2N.inj_pow, ?Nnat.Nat2N.inj_add in *.
+    change (N.of_nat 2) with 2%N in *.
+    pose proof mm_entry_size_pos level.
+    rewrite <-!N.div_div in * by
+        (change 0%N with (N.of_nat 0); rewrite ?Nnat.Nat2N.inj_iff;
+         try apply N.pow_nonzero; solver).
+    cbv [mm_index].
+    apply N.to_nat_le_iff.
+    rewrite !N.shiftr_div_pow2.
+    rewrite N.shiftl_1_l.
+    rewrite !N.land_ones' by auto using N.power_two_trivial.
+    rewrite N.log2_pow2 by lia.
+    rewrite !N.mod_eq by (apply N.pow_nonzero; solver).
+    match goal with
+    | H : (_ / _ = _ / _)%N |- _ => rewrite H
+    end.
+    apply N.sub_le_mono_r.
+    apply N.div_le_mono; try apply N.pow_nonzero; solver.
+  Qed.
 
   Lemma mm_index_capped level (a : ptable_addr_t) i :
     i < 2 ^ PAGE_LEVEL_BITS ->

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -304,10 +304,6 @@ Section Proofs.
     lia.
   Qed.
 
-  Lemma mm_start_of_next_block_level_end a level :
-    (mm_start_of_next_block a (mm_entry_size level) <= mm_level_end a level)%N.
-  Admitted. (* TODO *)
-
   (*** Proofs about [mm_level_end] ***)
 
   Lemma mm_level_end_lt a level : (a < mm_level_end a level)%N.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -162,37 +162,35 @@ Section Proofs.
 
   (*** Proofs about [mm_start_of_next_block] ***)
 
-  Lemma mm_start_of_next_block_eq a level :
-    mm_start_of_next_block a (mm_entry_size level)
-    = (a + mm_entry_size level - a mod mm_entry_size level)%N.
+  Lemma mm_start_of_next_block_eq a block_size :
+    N.is_power_of_two (N.of_nat block_size) ->
+    mm_start_of_next_block a block_size = (a + block_size - a mod block_size)%N.
   Proof.
-    cbv [mm_start_of_next_block mm_entry_size].
+    cbv [mm_start_of_next_block]; intros.
     repeat progress rewrite ?Nnat.N2Nat.inj_add, ?Nnat.N2Nat.inj_mul, ?Nnat.N2Nat.id.
-    rewrite N.and_not by auto using N.shiftl_power_two.
-    rewrite N.mod_add_cancel_r by (rewrite N.shiftl_eq_0_iff; lia).
-    rewrite N.shiftl_1_l.
+    rewrite N.and_not by auto.
+    rewrite N.mod_add_cancel_r by auto using N.power_two_nonzero.
     reflexivity.
   Qed.
 
-  Lemma mm_start_of_next_block_eq' a level :
-    mm_start_of_next_block a (mm_entry_size level)
-    = ((a / mm_entry_size level + 1) * mm_entry_size level)%N.
+  Lemma mm_start_of_next_block_eq' a block_size :
+    N.is_power_of_two (N.of_nat block_size) ->
+    @eq N (mm_start_of_next_block a block_size) ((a / block_size + 1) * block_size)%N.
   Proof.
-    rewrite mm_start_of_next_block_eq.
-    pose proof mm_entry_size_pos level.
-    pose proof N.mod_bound_pos a (mm_entry_size level).
+    intros. rewrite mm_start_of_next_block_eq by auto.
+    pose proof N.power_two_nonzero _ ltac:(eassumption).
+    pose proof N.mod_bound_pos a block_size.
     match goal with |- context [(?a + ?m - ?a mod ?m)%N] =>
                     replace (a + m - a mod m)%N with (m + (a - a mod m))%N
                       by (rewrite N.mod_eq; solver);
                       rewrite <-(N.mul_div a m) by solver
     end.
-    rewrite N.mul_add_distr_r, N.mul_1_l.
-    rewrite (N.mul_comm (mm_entry_size level)).
-    apply N.add_comm.
+    solver.
   Qed.
 
   Lemma mm_start_of_next_block_is_start a block_size :
     is_start_of_block (mm_start_of_next_block a block_size) block_size.
+  Proof.
   Admitted. (* TODO *)
 
   Lemma mm_start_of_next_block_shift a level :

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -189,9 +189,15 @@ Section Proofs.
   Qed.
 
   Lemma mm_start_of_next_block_is_start a block_size :
+    N.is_power_of_two (N.of_nat block_size) ->
     is_start_of_block (mm_start_of_next_block a block_size) block_size.
   Proof.
-  Admitted. (* TODO *)
+    cbv [is_start_of_block]; intros.
+    rewrite mm_start_of_next_block_eq' by auto.
+    rewrite N.land_ones' by auto.
+    rewrite N.pow2_log2 by auto.
+    apply N.mod_mul; auto using N.power_two_nonzero.
+  Qed.
 
   Lemma mm_start_of_next_block_shift a level :
     (mm_start_of_next_block a (mm_entry_size level)
@@ -224,7 +230,7 @@ Section Proofs.
     apply Nnat.N2Nat.inj_iff.
     rewrite !N.land_ones' by auto using N.shiftl_power_two.
     rewrite N.shiftl_1_l, N.log2_pow2 by lia.
-    rewrite mm_start_of_next_block_eq'.
+    rewrite mm_start_of_next_block_eq' by auto using mm_entry_size_power_two.
     cbv [mm_entry_size] in *.
     rewrite Nnat.N2Nat.id in *.
     remember (PAGE_BITS + level * PAGE_LEVEL_BITS)%N.
@@ -356,7 +362,7 @@ Section Proofs.
     mm_level_end (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_level_end a level.
   Proof.
     intros; apply mm_level_end_high_eq.
-    rewrite mm_start_of_next_block_eq'.
+    rewrite mm_start_of_next_block_eq' by auto using mm_entry_size_power_two.
     rewrite mm_entry_size_step.
     rewrite Nnat.Nat2N.inj_mul, Nat2N.inj_pow.
     change (N.of_nat 2) with 2%N.
@@ -784,8 +790,9 @@ Section Proofs.
         apply mm_map_level_pointers_ok.
         auto. }
       { (* is_begin_or_block_start start_begin begin  *)
-        cbv [is_begin_or_block_start].
-        right. apply mm_start_of_next_block_is_start. }
+        cbv [is_begin_or_block_start]. right.
+        apply mm_start_of_next_block_is_start;
+          auto using mm_entry_size_power_two. }
       { (* index sequences don't change *)
         cbv [table_index_expression] in *; simplify; [ ].
         apply Forall_forall; intros.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -138,7 +138,58 @@ Section Proofs.
     apply N.shiftl_power_two.
   Qed.
 
+  Lemma mm_entry_size_gt_1 level : (1 < mm_entry_size level)%N.
+  Proof.
+    intros; rewrite mm_entry_size_eq.
+    pose proof PAGE_BITS_pos.
+    rewrite Nat2N.inj_pow.
+    change 1%N with (2 ^ 0)%N.
+    change (N.of_nat 2) with 2%N.
+    apply N.pow_lt_mono_r; solver.
+  Qed.
+
+  Lemma mm_entry_size_pos level : (0 < mm_entry_size level)%N.
+  Proof. pose proof mm_entry_size_gt_1 level; solver. Qed.
+
+  Lemma mm_entry_size_step level :
+    mm_entry_size (level + 1) = mm_entry_size level * 2 ^ PAGE_LEVEL_BITS.
+  Proof.
+    rewrite !mm_entry_size_eq.
+    replace (PAGE_BITS + (level + 1) * PAGE_LEVEL_BITS)
+      with (PAGE_BITS + level * PAGE_LEVEL_BITS + PAGE_LEVEL_BITS) by solver.
+    apply Nat.pow_add_r.
+  Qed.
+
   (*** Proofs about [mm_start_of_next_block] ***)
+
+  Lemma mm_start_of_next_block_eq a level :
+    mm_start_of_next_block a (mm_entry_size level)
+    = (a + mm_entry_size level - a mod mm_entry_size level)%N.
+  Proof.
+    cbv [mm_start_of_next_block mm_entry_size].
+    repeat progress rewrite ?Nnat.N2Nat.inj_add, ?Nnat.N2Nat.inj_mul, ?Nnat.N2Nat.id.
+    rewrite N.and_not by auto using N.shiftl_power_two.
+    rewrite N.mod_add_cancel_r by (rewrite N.shiftl_eq_0_iff; lia).
+    rewrite N.shiftl_1_l.
+    reflexivity.
+  Qed.
+
+  Lemma mm_start_of_next_block_eq' a level :
+    mm_start_of_next_block a (mm_entry_size level)
+    = ((a / mm_entry_size level + 1) * mm_entry_size level)%N.
+  Proof.
+    rewrite mm_start_of_next_block_eq.
+    pose proof mm_entry_size_pos level.
+    pose proof N.mod_bound_pos a (mm_entry_size level).
+    match goal with |- context [(?a + ?m - ?a mod ?m)%N] =>
+                    replace (a + m - a mod m)%N with (m + (a - a mod m))%N
+                      by (rewrite N.mod_eq; solver);
+                      rewrite <-(N.mul_div a m) by solver
+    end.
+    rewrite N.mul_add_distr_r, N.mul_1_l.
+    rewrite (N.mul_comm (mm_entry_size level)).
+    apply N.add_comm.
+  Qed.
 
   Lemma mm_start_of_next_block_is_start a block_size :
     is_start_of_block (mm_start_of_next_block a block_size) block_size.
@@ -166,10 +217,29 @@ Section Proofs.
     lia.
   Qed.
 
+  Lemma mm_index_start_of_next_block_previous a b level :
+    (0 < b <= mm_entry_size level)%N ->
+    mm_index (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_index a level.
+  Proof.
+    (* TODO: clean up this proof! *)
+    cbv [mm_index]; intros.
+    apply Nnat.N2Nat.inj_iff.
+    rewrite !N.land_ones' by auto using N.shiftl_power_two.
+    rewrite N.shiftl_1_l, N.log2_pow2 by lia.
+    rewrite mm_start_of_next_block_eq'.
+    cbv [mm_entry_size] in *.
+    rewrite Nnat.N2Nat.id in *.
+    remember (PAGE_BITS + level * PAGE_LEVEL_BITS)%N.
+    rewrite !N.shiftl_1_l in *.
+    rewrite !N.shiftr_div_pow2.
+    rewrite N.div_sub_small by solver.
+    f_equal; lia.
+  Qed.
+
   (* helper lemma for mm_index_start_of_next_block *)
   Lemma level_bits_small a level :
     (mm_start_of_next_block a (mm_entry_size level) < mm_level_end a level)%N ->
-    ((a >> (PAGE_BITS + level * PAGE_LEVEL_BITS)) mod 2 ^ PAGE_LEVEL_BITS + 1 < 2 ^ PAGE_LEVEL_BITS)%N. 
+    ((a >> (PAGE_BITS + level * PAGE_LEVEL_BITS)) mod 2 ^ PAGE_LEVEL_BITS + 1 < 2 ^ PAGE_LEVEL_BITS)%N.
   Proof.
     (* TODO : clean up this proof! *)
     cbv [mm_level_end]; intros.
@@ -238,6 +308,71 @@ Section Proofs.
     (mm_start_of_next_block a (mm_entry_size level) <= mm_level_end a level)%N.
   Admitted. (* TODO *)
 
+  (*** Proofs about [mm_level_end] ***)
+
+  Lemma mm_level_end_lt a level : (a < mm_level_end a level)%N.
+  Proof.
+    cbv [mm_level_end]; intros.
+    rewrite N.shiftr_add_shiftl.
+    rewrite N.shiftl_1_l.
+    match goal with
+    | |- context [(2 ^ ?x)%N] =>
+      pose proof (N.pow_nonzero 2 x)
+    end.
+    match goal with
+    | |- context [(?x mod ?y)%N] =>
+      pose proof (N.mod_bound_pos x y)
+    end.
+    lia.
+  Qed.
+
+  Lemma mm_level_end_le a level : (a <= mm_level_end a level)%N.
+  Proof.
+    intros; apply N.lt_le_incl; apply mm_level_end_lt.
+  Qed.
+
+  Lemma mm_level_end_high_eq a b level :
+    (a / mm_entry_size (level + 1))%N = (b / mm_entry_size (level + 1))%N <->
+    mm_level_end a level = mm_level_end b level.
+  Proof.
+    cbv [mm_level_end]; intros.
+    rewrite !N.shiftr_div_pow2.
+    match goal with |- context [(2 ^ N.of_nat ?x)%N] =>
+                    replace (2 ^ N.of_nat x)%N with (N.of_nat (2 ^ x)) by apply Nat2N.inj_pow
+    end.
+    rewrite <-mm_entry_size_eq.
+    rewrite <-N.shiftl_inj_iff.
+    split; solver.
+  Qed.
+
+  Lemma mm_level_end_eq a b c level :
+    mm_level_end a level = mm_level_end c level ->
+    (a <= b <= c)%N ->
+    mm_level_end b level = mm_level_end a level.
+  Proof.
+    rewrite <-!mm_level_end_high_eq; intros.
+    pose proof mm_entry_size_pos (level + 1).
+    apply N.mul_cancel_l with (p:=mm_entry_size (level + 1));
+      try solver; [ ].
+    rewrite (N.div_between_eq a b c); solver.
+  Qed.
+
+  Lemma mm_level_end_start_of_next_block_previous a b level :
+    (0 < b < mm_entry_size level)%N ->
+    mm_level_end (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_level_end a level.
+  Proof.
+    intros; apply mm_level_end_high_eq.
+    rewrite mm_start_of_next_block_eq'.
+    rewrite mm_entry_size_step.
+    rewrite Nnat.Nat2N.inj_mul, Nat2N.inj_pow.
+    change (N.of_nat 2) with 2%N.
+    pose proof N.pow_nonzero 2%N PAGE_LEVEL_BITS.
+    rewrite <-!N.div_div by solver.
+    rewrite N.div_sub_small by solver.
+    rewrite N.add_sub.
+    reflexivity.
+  Qed.
+
   (*** Proofs about [mm_index] ***)
 
   Lemma mm_index_le_mono a b level :
@@ -267,28 +402,23 @@ Section Proofs.
       solver. }
   Qed.
 
-  (*** Proofs about [mm_level_end] ***)
-
-  Lemma mm_level_end_lt a level : (a < mm_level_end a level)%N.
+  Lemma mm_index_eq a b level :
+    (a <= b)%N ->
+    mm_level_end a level = mm_level_end b level ->
+    (mm_index a level <= mm_index b level)%N ->
+    (b < mm_start_of_next_block a (mm_entry_size level))%N ->
+    mm_index b level = mm_index a level.
   Proof.
-    cbv [mm_level_end]; intros.
-    rewrite N.shiftr_add_shiftl.
-    rewrite N.shiftl_1_l.
-    match goal with
-    | |- context [(2 ^ ?x)%N] =>
-      pose proof (N.pow_nonzero 2 x)
-    end.
-    match goal with
-    | |- context [(?x mod ?y)%N] =>
-      pose proof (N.mod_bound_pos x y)
-    end.
-    lia.
+    intros; apply Nat.le_antisymm;
+      [ | solve [auto using mm_index_le_mono] ].
+    pose proof mm_entry_size_gt_1 level.
+    let H := fresh in
+    assert (b <= mm_start_of_next_block a (mm_entry_size level) - 1)%N as H by lia;
+      apply mm_index_le_mono with (level:=level) in H.
+    { rewrite mm_index_start_of_next_block_previous in *; solver. }
+    { rewrite mm_level_end_start_of_next_block_previous; solver. }
   Qed.
 
-  Lemma mm_level_end_le a level : (a <= mm_level_end a level)%N.
-  Proof.
-    intros; apply N.lt_le_incl; apply mm_level_end_lt.
-  Qed.
 
   (*** Proofs about [mm_free_page_pte] ***)
 
@@ -527,156 +657,6 @@ Section Proofs.
              | _ => rewrite while_loop_noop; [solver|]
              | _ => apply N.ltb_ge; solver
              end.
-  Qed.
-
-  (* TODO: move and use in mm_start_of_next_block_shift *)
-  Lemma mm_start_of_next_block_eq a level :
-    mm_start_of_next_block a (mm_entry_size level)
-    = (a + mm_entry_size level - a mod mm_entry_size level)%N.
-  Proof.
-    cbv [mm_start_of_next_block mm_entry_size].
-    repeat progress rewrite ?Nnat.N2Nat.inj_add, ?Nnat.N2Nat.inj_mul, ?Nnat.N2Nat.id.
-    rewrite N.and_not by auto using N.shiftl_power_two.
-    rewrite N.mod_add_cancel_r by (rewrite N.shiftl_eq_0_iff; lia).
-    rewrite N.shiftl_1_l.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_index_start_of_next_block_previous a b level :
-    (0 < b <= mm_entry_size level)%N ->
-    mm_index (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_index a level.
-  Proof.
-    (* TODO: clean up this proof! *)
-    cbv [mm_index]; intros.
-    apply Nnat.N2Nat.inj_iff.
-    rewrite !N.land_ones' by auto using N.shiftl_power_two.
-    rewrite N.shiftl_1_l, N.log2_pow2 by lia.
-    rewrite mm_start_of_next_block_eq.
-    cbv [mm_entry_size] in *.
-    rewrite Nnat.N2Nat.id in *.
-    remember (PAGE_BITS + level * PAGE_LEVEL_BITS)%N.
-    match goal with
-    | |- context [(?x + ?m - ?x mod ?m - ?z)%N] =>
-      pose proof N.mul_div_le x m;
-        replace (x + m - x mod m - z)%N with (m * (x / m) + m - z)%N by (rewrite N.mod_eq; solver);
-        replace (m * (x / m) + m - z)%N with ((x / m) * m + (m - z))%N by solver (* format for N.div_add_l *)
-                                                                            (* TODO: use N.div_add_l' *)
-                                                                            (* TODO: maybe use mm_start_of_next_block_eq' instead *)
-    end.
-    rewrite !N.shiftl_1_l in *.
-    rewrite !N.shiftr_div_pow2.
-    rewrite N.div_add_l by (apply N.pow_nonzero; solver).
-    rewrite (N.div_small (_ - _)%N) by solver.
-    f_equal; lia.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_level_end_high_eq a b level :
-    (a / mm_entry_size (level + 1))%N = (b / mm_entry_size (level + 1))%N <->
-    mm_level_end a level = mm_level_end b level.
-  Proof.
-    cbv [mm_level_end]; intros.
-    rewrite !N.shiftr_div_pow2.
-    match goal with |- context [(2 ^ N.of_nat ?x)%N] =>
-                    replace (2 ^ N.of_nat x)%N with (N.of_nat (2 ^ x)) by apply Nat2N.inj_pow
-    end.
-    rewrite <-mm_entry_size_eq.
-    rewrite <-N.shiftl_inj_iff.
-    split; solver.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_entry_size_pos level : (0 < mm_entry_size level)%N.
-  Proof.
-    rewrite mm_entry_size_eq.
-    apply N.neq_0_lt_0.
-    rewrite Nat2N.inj_pow.
-    apply N.pow_nonzero. solver.
-  Qed.
-  Lemma mm_entry_size_gt_1 level : (1 < mm_entry_size level)%N.
-  Proof.
-    intros; rewrite mm_entry_size_eq.
-    pose proof PAGE_BITS_pos.
-    rewrite Nat2N.inj_pow.
-    change 1%N with (2 ^ 0)%N.
-    change (N.of_nat 2) with 2%N.
-    apply N.pow_lt_mono_r; solver.
-  Qed.
-
-  (* TODO: move *)
-  Lemma mm_start_of_next_block_eq' a level :
-    mm_start_of_next_block a (mm_entry_size level)
-    = ((a / mm_entry_size level + 1) * mm_entry_size level)%N.
-  Proof.
-    rewrite mm_start_of_next_block_eq.
-    pose proof mm_entry_size_pos level.
-    pose proof N.mod_bound_pos a (mm_entry_size level).
-    match goal with |- context [(?a + ?m - ?a mod ?m)%N] =>
-                    replace (a + m - a mod m)%N with (m + (a - a mod m))%N
-                      by (rewrite N.mod_eq; solver);
-                      rewrite <-(N.mul_div a m) by solver
-    end.
-    rewrite N.mul_add_distr_r, N.mul_1_l.
-    rewrite (N.mul_comm (mm_entry_size level)).
-    apply N.add_comm.
-  Qed.
-
-  Lemma mm_entry_size_step level :
-    mm_entry_size (level + 1) = mm_entry_size level * 2 ^ PAGE_LEVEL_BITS.
-  Proof.
-    rewrite !mm_entry_size_eq.
-    replace (PAGE_BITS + (level + 1) * PAGE_LEVEL_BITS)
-      with (PAGE_BITS + level * PAGE_LEVEL_BITS + PAGE_LEVEL_BITS) by solver.
-    apply Nat.pow_add_r.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_level_end_start_of_next_block_previous a b level :
-    (0 < b < mm_entry_size level)%N ->
-    mm_level_end (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_level_end a level.
-  Proof.
-    intros; apply mm_level_end_high_eq.
-    rewrite mm_start_of_next_block_eq'.
-    rewrite mm_entry_size_step.
-    rewrite Nnat.Nat2N.inj_mul, Nat2N.inj_pow.
-    change (N.of_nat 2) with 2%N.
-    pose proof N.pow_nonzero 2%N PAGE_LEVEL_BITS.
-    rewrite <-!N.div_div by solver.
-    rewrite N.div_sub_small by solver.
-    rewrite N.add_sub.
-    reflexivity.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_level_end_eq a b c level :
-    mm_level_end a level = mm_level_end c level ->
-    (a <= b <= c)%N ->
-    mm_level_end b level = mm_level_end a level.
-  Proof.
-    rewrite <-!mm_level_end_high_eq; intros.
-    pose proof mm_entry_size_pos (level + 1).
-    apply N.mul_cancel_l with (p:=mm_entry_size (level + 1));
-      try solver; [ ].
-    rewrite (N.div_between_eq a b c); solver.
-  Qed.
-
-  (* TODO : move *)
-  Lemma mm_index_eq a b level :
-    (a <= b)%N ->
-    mm_level_end a level = mm_level_end b level ->
-    (mm_index a level <= mm_index b level)%N ->
-    (b < mm_start_of_next_block a (mm_entry_size level))%N ->
-    mm_index b level = mm_index a level.
-  Proof.
-    intros; apply Nat.le_antisymm;
-      [ | solve [auto using mm_index_le_mono] ].
-    pose proof mm_entry_size_gt_1 level.
-    let H := fresh in
-    assert (b <= mm_start_of_next_block a (mm_entry_size level) - 1)%N as H by lia;
-      apply mm_index_le_mono with (level:=level) in H.
-    { rewrite mm_index_start_of_next_block_previous in *; solver. }
-    { rewrite mm_level_end_start_of_next_block_previous; solver. }
   Qed.
 
   (* TODO:

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -78,6 +78,7 @@ Qed.
    a valid abstract state. *)
 Lemma execution_represents
       {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
+      {cp_ok : params_valid}
       (start_state : concrete_state) (trace : list api_call) :
   (exists abst, represents_valid abst start_state) ->
   exists abst, represents_valid abst (execute_trace start_state trace).
@@ -97,7 +98,8 @@ Qed.
      the invariants; that is, if you obey the invariants at the start, no
      sequence of api calls can make you stop obeying them. ***)
 Theorem execution_preserves_invariants
-        {ap : abstract_state_parameters} {cp : concrete_params} :
+        {ap : abstract_state_parameters} {cp : concrete_params}
+        {cp_ok : params_valid} :
   forall (trace : list api_call) (start_state : concrete_state),
     obeys_invariants start_state ->
     obeys_invariants (execute_trace start_state trace).

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -71,6 +71,18 @@ Definition reassign_pointer
     api_page_pool := s.(api_page_pool);
   |}.
 
+Class params_valid {cp : concrete_params} :=
+  {
+    correct_number_of_root_tables_stage1 :
+      length (ptr_from_va (va_from_pa (hafnium_ptable.(root))))
+      = arch_mm_stage1_root_table_count;
+    correct_number_of_root_tables_stage2 :
+      forall t,
+        In t (map vm_ptable vms) ->
+        length (ptr_from_va (va_from_pa t.(root)))
+        = arch_mm_stage2_root_table_count
+  }.
+
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
   (* Possible constraints:
         - Block PTEs have the valid bit set

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -74,6 +74,12 @@ Module N.
       auto using N.log2_nonneg; solver.
   Qed.
 
+  Lemma power_two_nonzero (n : N) :
+    is_power_of_two n -> n <> 0.
+  Proof.
+    intros; pose proof power_two_pos n ltac:(assumption); solver.
+  Qed.
+
   Lemma shiftl_power_two n :
     is_power_of_two (N.shiftl 1 n).
   Proof.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -64,7 +64,7 @@ Hint Rewrite N.shiftl_1_l N.shiftl_mul_pow2 N.shiftr_div_pow2 N.land_ones
 
 (* Add common side conditions for N lemmas to [auto] *)
 Hint Resolve N.pow_nonzero N.div_le_mono N.mod_bound_pos N.neq_0_lt_0 N.le_0_l
-     N.lt_le_incl.
+     N.lt_le_incl N.mod_le.
 
 Ltac nsimplify := autorewrite with nsimplify.
 Ltac nsimplify_all := autorewrite with nsimplify in *.
@@ -342,7 +342,12 @@ Module N.
 
   Lemma shiftr_add_shiftl a b n :
     N.shiftl (N.shiftr a n + b) n = a + N.shiftl b n - a mod (2 ^ n).
-  Admitted.
+  Proof.
+    autorewrite with bits2arith push_nmul.
+    rewrite mul_div' by auto.
+    rewrite N.add_sub_swap by auto.
+    solver.
+  Qed.
 End N.
 Hint Resolve N.to_nat_lt_iff N.to_nat_le_iff.
 

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -189,11 +189,11 @@ Module N.
   Lemma mod_sub_small a b c :
     c <> 0 ->
     0 < a ->
-    0 < b < c ->
+    0 < b <= c ->
     (a * c - b) mod c = c - b.
   Proof.
     intros.
-    assert (b < a * c) by nia.
+    assert (b <= a * c) by nia.
     transitivity ((a * c - b + c) mod c);
       [ rewrite N.add_mod, N.mod_same, N.add_0_r, N.mod_mod by solver;
         reflexivity | ].
@@ -206,7 +206,7 @@ Module N.
 
   Lemma div_sub_small a b c :
     c <> 0 ->
-    (0 < b < c) ->
+    (0 < b <= c) ->
     (a * c - b) / c = a - 1.
   Proof.
     intros.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -344,8 +344,7 @@ Module N.
     N.shiftl (N.shiftr a n + b) n = a + N.shiftl b n - a mod (2 ^ n).
   Proof.
     autorewrite with bits2arith push_nmul.
-    rewrite mul_div' by auto.
-    rewrite N.add_sub_swap by auto.
+    rewrite mul_div', N.add_sub_swap by auto.
     solver.
   Qed.
 End N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -58,4 +58,30 @@ Module N.
 
   Lemma log2_add_shiftl_1 a b : b <= N.log2 (a + (N.shiftl 1 b)).
   Admitted. (* TODO *)
+
+  Definition is_power_of_two (n : N) : Prop := n = N.pow 2 (N.log2 n).
+
+  Lemma power_two_pos (n : N) :
+    is_power_of_two n ->
+    (0 < n)%N.
+  Proof.
+    cbv [is_power_of_two]; intro H; rewrite H.
+    apply N.lt_le_trans with (m:=2 ^ 0);
+      [ rewrite N.pow_0_r; solver | ].
+    apply N.pow_le_mono_r;
+      auto using N.log2_nonneg; solver.
+  Qed.
+
+  Lemma shiftl_power_two n :
+    is_power_of_two (N.shiftl 1 n).
+  Proof.
+    cbv [is_power_of_two].
+    rewrite N.shiftl_1_l, N.log2_pow2 by solver.
+    reflexivity.
+  Qed.
+
+  Lemma and_not a b :
+    is_power_of_two b ->
+    (N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b)%N.
+  Admitted.
 End N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -17,9 +17,11 @@
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.BinNat.
 Require Import Coq.NArith.Nnat.
+Require Import Coq.micromega.Lia.
 Require Import Hafnium.Util.Tactics.
 Local Open Scope N_scope.
 
+(* TODO: organize this file; for instance, keep the lemmas about [shiftr] together *)
 Module N.
   Lemma to_nat_ltb (x y : N) :
     (x <? y)%N = (N.to_nat x <? N.to_nat y)%nat.
@@ -82,12 +84,12 @@ Module N.
 
   Lemma and_not a b :
     is_power_of_two b ->
-    (N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b)%N.
+    N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b.
   Admitted. (* TODO *)
 
   Lemma power_two_minus_1 n :
     is_power_of_two n ->
-    (n - 1 = N.ones (N.log2 n))%N.
+    n - 1 = N.ones (N.log2 n).
   Proof.
     cbv [is_power_of_two]; intros.
     rewrite N.ones_equiv. solver.
@@ -95,7 +97,7 @@ Module N.
 
   Lemma land_ones' a b :
     is_power_of_two b ->
-    (N.land a (b - 1) = a mod (2 ^ N.log2 b))%N.
+    N.land a (b - 1) = a mod (2 ^ N.log2 b).
   Proof.
     intros. rewrite power_two_minus_1 by auto.
     apply N.land_ones.
@@ -108,12 +110,145 @@ Module N.
     rewrite N.log2_pow2; solver.
   Qed.
 
+  Definition lt_le_dec n m : {n < m} + {m <= n}.
+  Proof.
+    destruct (N.eq_dec n m); [ right; solver | ].
+    destruct (N.min_dec n m); [left | right ]; solver.
+  Defined.
+
+  Lemma mod_add_cancel_r a b : b <> 0 -> (a + b) mod b = a mod b.
+  Proof.
+    repeat match goal with
+           | _ => progress basics
+           | _ => rewrite N.mod_same by auto
+           | _ => rewrite N.mod_mod by auto
+           | _ => rewrite N.add_0_r
+           | _ => rewrite (N.add_mod a b) by auto
+           | _ => solver
+           end.
+  Qed.
+
+  Lemma lt_pred_le a b : a < b -> a <= N.pred b.
+  Proof. basics; solver. Qed.
+
+  Lemma shiftr_le_mono_r a b n :
+    (a <= b) -> N.shiftr a n <= N.shiftr b n.
+  Proof.
+    repeat match goal with
+           | _ => progress basics
+           | _ => rewrite N.shiftr_div_pow2
+           | _ => apply N.div_le_mono
+           | _ => apply N.pow_nonzero
+           | _ => solver
+           end.
+  Qed.
+
+  Lemma shiftr_lt_shiftl_mono a b n :
+    a < (N.shiftl b n) -> N.shiftr a n < b.
+  Proof.
+    repeat match goal with
+           | _ => progress basics
+           | _ => rewrite N.shiftl_mul_pow2 in *
+           | _ => rewrite N.shiftr_div_pow2
+           | _ => apply N.div_lt_upper_bound
+           | _ => apply N.pow_nonzero
+           | _ => solver
+           end.
+  Qed.
+
+  Lemma shiftl_inj_iff a b n :
+    a = b <-> N.shiftl a n = N.shiftl b n.
+  Proof.
+    rewrite !N.shiftl_mul_pow2.
+    rewrite N.mul_cancel_r by (apply N.pow_nonzero; solver).
+    reflexivity.
+  Qed.
+
+  Lemma div_add_l' a b c :
+    b <> 0 -> (b * a + c) / b = a + c / b.
+  Proof. intros. rewrite (N.mul_comm b a). apply N.div_add_l; auto. Qed.
+
+  Lemma mul_div a b : b <> 0 -> b * (a / b) = a - a mod b.
+  Proof.
+    (* TODO: this proof badly needs some autorewrite dbs *)
+    intros.
+    rewrite (N.div_mod a b) by auto.
+    rewrite div_add_l' by auto.
+    rewrite N.mul_add_distr_l.
+    rewrite (N.div_small (_ mod _)) by (apply N.mod_bound_pos; solver).
+    rewrite N.mul_0_r, N.add_0_r by auto.
+    rewrite N.add_mod by auto.
+    rewrite N.mul_mod by auto.
+    rewrite N.mod_same by auto.
+    rewrite N.mod_mod by auto.
+    rewrite N.mul_0_l, N.mod_0_l, N.add_0_l by auto.
+    rewrite N.mod_mod by auto.
+    solver.
+  Qed.
+
+  Lemma mod_sub_small a b c :
+    c <> 0 ->
+    0 < a ->
+    0 < b < c ->
+    (a * c - b) mod c = c - b.
+  Proof.
+    intros.
+    assert (b < a * c) by nia.
+    transitivity ((a * c - b + c) mod c);
+      [ rewrite N.add_mod, N.mod_same, N.add_0_r, N.mod_mod by solver;
+        reflexivity | ].
+    rewrite <-N.add_sub_swap by solver.
+    rewrite <-N.add_sub_assoc by solver.
+    rewrite N.add_mod, N.mod_mul, N.add_0_l, N.mod_mod by solver.
+    rewrite !N.mod_small by solver.
+    reflexivity.
+  Qed.
+
+  Lemma div_sub_small a b c :
+    c <> 0 ->
+    (0 < b < c) ->
+    (a * c - b) / c = a - 1.
+  Proof.
+    intros.
+    destruct (N.eq_dec a 0); [ subst; solver | ].
+    apply N.mul_cancel_l with (p:=c); [solver | ].
+    rewrite mul_div by solver.
+    rewrite mod_sub_small by solver.
+    rewrite N.mul_sub_distr_l, N.mul_1_r.
+    solver.
+  Qed.
+
+  Lemma div_between_eq a b c d :
+    d <> 0 ->
+    a <= b <= c ->
+    a / d = c / d ->
+    b / d = a / d.
+  Proof.
+    intros.
+    match goal with
+    | H : (?a / ?d = ?c / ?d) |- _ =>
+      replace c with (d * (a / d) + (a mod d + (c - a))) in H
+        by (rewrite N.add_assoc, <-N.div_mod; lia)
+    end.
+    replace b with (d * (a / d) + (a mod d + (b - a)))
+      by (rewrite N.add_assoc, <-N.div_mod; lia).
+    rewrite !div_add_l' in * by auto.
+    assert ((a mod d + (c - a)) / d = 0) as Hdivsmall by lia.
+    rewrite N.div_small_iff in Hdivsmall by auto.
+    rewrite (N.div_small (_ + _)) by lia.
+    lia.
+  Qed.
+
+  Lemma shiftr_add_shiftl a b n :
+    N.shiftl (N.shiftr a n + b) n = a + N.shiftl b n - a mod (2 ^ n).
+  Admitted.
+
 End N.
 Hint Resolve N.to_nat_lt_iff N.to_nat_le_iff.
 
 Module Nat2N.
   Lemma inj_pow a b :
-    N.of_nat (a ^ b) = (N.of_nat a ^ N.of_nat b)%N.
+    N.of_nat (a ^ b) = N.of_nat a ^ N.of_nat b.
   Proof.
     induction b.
     { rewrite Nat.pow_0_r, N.pow_0_r. reflexivity. }

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -83,5 +83,44 @@ Module N.
   Lemma and_not a b :
     is_power_of_two b ->
     (N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b)%N.
-  Admitted.
+  Admitted. (* TODO *)
+
+  Lemma power_two_minus_1 n :
+    is_power_of_two n ->
+    (n - 1 = N.ones (N.log2 n))%N.
+  Proof.
+    cbv [is_power_of_two]; intros.
+    rewrite N.ones_equiv. solver.
+  Qed.
+
+  Lemma land_ones' a b :
+    is_power_of_two b ->
+    (N.land a (b - 1) = a mod (2 ^ N.log2 b))%N.
+  Proof.
+    intros. rewrite power_two_minus_1 by auto.
+    apply N.land_ones.
+  Qed.
+
+  Lemma power_two_trivial n :
+    is_power_of_two (2 ^ n).
+  Proof.
+    cbv [is_power_of_two].
+    rewrite N.log2_pow2; solver.
+  Qed.
+
 End N.
+Hint Resolve N.to_nat_lt_iff N.to_nat_le_iff.
+
+Module Nat2N.
+  Lemma inj_pow a b :
+    N.of_nat (a ^ b) = (N.of_nat a ^ N.of_nat b)%N.
+  Proof.
+    induction b.
+    { rewrite Nat.pow_0_r, N.pow_0_r. reflexivity. }
+    { rewrite Nat.pow_succ_r by solver.
+      rewrite Nnat.Nat2N.inj_succ.
+      rewrite N.pow_succ_r by solver.
+      rewrite Nnat.Nat2N.inj_mul.
+      solver. }
+  Qed.
+End Nat2N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -134,7 +134,10 @@ Module N.
   Qed.
 
   Lemma to_nat_lt_iff x y : (N.to_nat x < N.to_nat y)%nat <-> x < y.
-  Admitted. (* TODO *)
+  Proof.
+    rewrite <-N.compare_lt_iff, <-Nat.compare_lt_iff.
+    rewrite N2Nat.inj_compare. reflexivity.
+  Qed.
 
   (* this lemma exists to be added to [auto], so [auto] can solve [2 ^ _ <> 0] by
      [N.pow_nonneg] *)

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -88,6 +88,14 @@ Module N.
     reflexivity.
   Qed.
 
+  Lemma pow2_log2 (n : N) :
+    is_power_of_two n -> 2 ^ N.log2 n = n.
+  Proof.
+    cbv [is_power_of_two]; intro H; rewrite H.
+    rewrite N.log2_pow2 by solver.
+    reflexivity.
+  Qed.
+
   Lemma and_not a b :
     is_power_of_two b ->
     N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -333,7 +333,10 @@ Section ListQualifiers.
 
   Lemma Forall_map {A B} (P : B -> Prop) (f : A -> B) ls :
     Forall P (map f ls) -> Forall (fun a => P (f a)) ls.
-  Admitted. (* TODO *)
+  Proof.
+    induction ls; cbn [map]; intros; [solver|].
+    invert_list_properties. solver.
+  Qed.
 
   (*** Some proofs about [ForallOrdPairs] ***)
 

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -151,7 +151,9 @@ Section NthDefault.
   Lemma In_nth_default ls i :
     i < length ls ->
     In (nth_default d ls i) ls.
-  Admitted. (* TODO *)
+  Proof.
+    intros; rewrite nth_default_eq; auto using nth_In.
+  Qed.
 End NthDefault.
 Hint Rewrite @nth_default_nil @nth_default_cons : push_nth_default.
 
@@ -170,7 +172,11 @@ Section FoldRight.
   Lemma fold_right_ext (f g : A -> B -> B) b ls :
     (forall a b, In a ls -> f a b = g a b) ->
     fold_right f b ls = fold_right g b ls.
-  Admitted. (* TODO *)
+  Proof.
+    intro Hfg.
+    induction ls; cbn [fold_right];
+      rewrite ?IHls, ?Hfg by solver; solver.
+  Qed.
 End FoldRight.
 
 Section FoldLeft.
@@ -190,10 +196,17 @@ End FoldLeft.
 Section FirstnSkipn.
   Context {A : Type}.
 
-  Lemma firstn_snoc i ls d :
-    i < length ls ->
-    @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
-  Admitted. (* TODO *)
+  Lemma firstn_snoc ls d :
+    forall i,
+      i < length ls ->
+      @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
+  Proof.
+    induction ls; intros;
+      autorewrite with push_nth_default push_length in *; [solver|].
+    cbn [firstn]. destruct i; [reflexivity|].
+    rewrite IHls by solver.
+    reflexivity.
+  Qed.
 
   Lemma in_firstn (a : A) ls : forall i, In a (firstn i ls) -> In a ls.
   Proof.


### PR DESCRIPTION
The `mm_map_root` proof last week left a lot of admitted lemmas about the bit-fiddling in `mm.c` (`mm_index`, `mm_start_of_next_block`, `mm_level_end`, etc.). In this PR, I prove most of them, which involves a lot of fairly tedious arithmetic reasoning. The changes in `Util/BinNat.v` are all very general facts about unsigned binary numbers that aren't Hafnium-specific, so they can be safely overlooked in code review. At this point, most of the functionality of these low-level functions has been encoded, so future proofs of the more complex functions in `mm.c` shouldn't require too many more proofs about them.

This PR also includes a precondition to all concrete states saying that, when you use the `addr.c` functions to get a list of page tables from the root page table pointers, you get a number of root tables that matches the one given by `arch_mm_stage{1,2}_root_table_count`. This allowed me to alter a precondition on `mm_map_root` from  `mm_index end_ level < length (mm_page_table_from_pa t.(root))` to instead say `end_ <= mm_root_table_count flags * mm_entry_size root_level`. The latter matches what the caller of `mm_map_root` actually ensures.