### PR TITLE
Prove remaining admitted low-level lemmas

### DIFF
--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -379,7 +379,29 @@ Section Proofs.
     (a <= b)%N ->
     mm_level_end a level = mm_level_end b level ->
     mm_index a level <= mm_index b level.
-  Admitted. (* TODO *)
+  Proof.
+    rewrite <-mm_level_end_high_eq; intros.
+    rewrite mm_entry_size_step in *.
+    rewrite mm_entry_size_eq in *.
+    repeat progress rewrite ?Nnat.Nat2N.inj_mul, ?Nat2N.inj_pow, ?Nnat.Nat2N.inj_add in *.
+    change (N.of_nat 2) with 2%N in *.
+    pose proof mm_entry_size_pos level.
+    rewrite <-!N.div_div in * by
+        (change 0%N with (N.of_nat 0); rewrite ?Nnat.Nat2N.inj_iff;
+         try apply N.pow_nonzero; solver).
+    cbv [mm_index].
+    apply N.to_nat_le_iff.
+    rewrite !N.shiftr_div_pow2.
+    rewrite N.shiftl_1_l.
+    rewrite !N.land_ones' by auto using N.power_two_trivial.
+    rewrite N.log2_pow2 by lia.
+    rewrite !N.mod_eq by (apply N.pow_nonzero; solver).
+    match goal with
+    | H : (_ / _ = _ / _)%N |- _ => rewrite H
+    end.
+    apply N.sub_le_mono_r.
+    apply N.div_le_mono; try apply N.pow_nonzero; solver.
+  Qed.
 
   Lemma mm_index_capped level (a : ptable_addr_t) i :
     i < 2 ^ PAGE_LEVEL_BITS ->

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -189,9 +189,15 @@ Section Proofs.
   Qed.
 
   Lemma mm_start_of_next_block_is_start a block_size :
+    N.is_power_of_two (N.of_nat block_size) ->
     is_start_of_block (mm_start_of_next_block a block_size) block_size.
   Proof.
-  Admitted. (* TODO *)
+    cbv [is_start_of_block]; intros.
+    rewrite mm_start_of_next_block_eq' by auto.
+    rewrite N.land_ones' by auto.
+    rewrite N.pow2_log2 by auto.
+    apply N.mod_mul; auto using N.power_two_nonzero.
+  Qed.
 
   Lemma mm_start_of_next_block_shift a level :
     (mm_start_of_next_block a (mm_entry_size level)
@@ -224,7 +230,7 @@ Section Proofs.
     apply Nnat.N2Nat.inj_iff.
     rewrite !N.land_ones' by auto using N.shiftl_power_two.
     rewrite N.shiftl_1_l, N.log2_pow2 by lia.
-    rewrite mm_start_of_next_block_eq'.
+    rewrite mm_start_of_next_block_eq' by auto using mm_entry_size_power_two.
     cbv [mm_entry_size] in *.
     rewrite Nnat.N2Nat.id in *.
     remember (PAGE_BITS + level * PAGE_LEVEL_BITS)%N.
@@ -356,7 +362,7 @@ Section Proofs.
     mm_level_end (mm_start_of_next_block a (mm_entry_size level) - b) level = mm_level_end a level.
   Proof.
     intros; apply mm_level_end_high_eq.
-    rewrite mm_start_of_next_block_eq'.
+    rewrite mm_start_of_next_block_eq' by auto using mm_entry_size_power_two.
     rewrite mm_entry_size_step.
     rewrite Nnat.Nat2N.inj_mul, Nat2N.inj_pow.
     change (N.of_nat 2) with 2%N.
@@ -784,8 +790,9 @@ Section Proofs.
         apply mm_map_level_pointers_ok.
         auto. }
       { (* is_begin_or_block_start start_begin begin  *)
-        cbv [is_begin_or_block_start].
-        right. apply mm_start_of_next_block_is_start. }
+        cbv [is_begin_or_block_start]. right.
+        apply mm_start_of_next_block_is_start;
+          auto using mm_entry_size_power_two. }
       { (* index sequences don't change *)
         cbv [table_index_expression] in *; simplify; [ ].
         apply Forall_forall; intros.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -64,7 +64,7 @@ Hint Rewrite N.shiftl_1_l N.shiftl_mul_pow2 N.shiftr_div_pow2 N.land_ones
 
 (* Add common side conditions for N lemmas to [auto] *)
 Hint Resolve N.pow_nonzero N.div_le_mono N.mod_bound_pos N.neq_0_lt_0 N.le_0_l
-     N.lt_le_incl.
+     N.lt_le_incl N.mod_le.
 
 Ltac nsimplify := autorewrite with nsimplify.
 Ltac nsimplify_all := autorewrite with nsimplify in *.
@@ -342,7 +342,12 @@ Module N.
 
   Lemma shiftr_add_shiftl a b n :
     N.shiftl (N.shiftr a n + b) n = a + N.shiftl b n - a mod (2 ^ n).
-  Admitted.
+  Proof.
+    autorewrite with bits2arith push_nmul.
+    rewrite mul_div' by auto.
+    rewrite N.add_sub_swap by auto.
+    solver.
+  Qed.
 End N.
 Hint Resolve N.to_nat_lt_iff N.to_nat_le_iff.
 

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -344,8 +344,7 @@ Module N.
     N.shiftl (N.shiftr a n + b) n = a + N.shiftl b n - a mod (2 ^ n).
   Proof.
     autorewrite with bits2arith push_nmul.
-    rewrite mul_div' by auto.
-    rewrite N.add_sub_swap by auto.
+    rewrite mul_div', N.add_sub_swap by auto.
     solver.
   Qed.
 End N.

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -134,7 +134,10 @@ Module N.
   Qed.
 
   Lemma to_nat_lt_iff x y : (N.to_nat x < N.to_nat y)%nat <-> x < y.
-  Admitted. (* TODO *)
+  Proof.
+    rewrite <-N.compare_lt_iff, <-Nat.compare_lt_iff.
+    rewrite N2Nat.inj_compare. reflexivity.
+  Qed.
 
   (* this lemma exists to be added to [auto], so [auto] can solve [2 ^ _ <> 0] by
      [N.pow_nonneg] *)

--- a/coq-verification/src/Util/BinNat.v
+++ b/coq-verification/src/Util/BinNat.v
@@ -88,6 +88,14 @@ Module N.
     reflexivity.
   Qed.
 
+  Lemma pow2_log2 (n : N) :
+    is_power_of_two n -> 2 ^ N.log2 n = n.
+  Proof.
+    cbv [is_power_of_two]; intro H; rewrite H.
+    rewrite N.log2_pow2 by solver.
+    reflexivity.
+  Qed.
+
   Lemma and_not a b :
     is_power_of_two b ->
     N.land a (N.lnot (b - 1) (N.size a)) = a - a mod b.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -333,7 +333,10 @@ Section ListQualifiers.
 
   Lemma Forall_map {A B} (P : B -> Prop) (f : A -> B) ls :
     Forall P (map f ls) -> Forall (fun a => P (f a)) ls.
-  Admitted. (* TODO *)
+  Proof.
+    induction ls; cbn [map]; intros; [solver|].
+    invert_list_properties. solver.
+  Qed.
 
   (*** Some proofs about [ForallOrdPairs] ***)
 

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -151,7 +151,9 @@ Section NthDefault.
   Lemma In_nth_default ls i :
     i < length ls ->
     In (nth_default d ls i) ls.
-  Admitted. (* TODO *)
+  Proof.
+    intros; rewrite nth_default_eq; auto using nth_In.
+  Qed.
 End NthDefault.
 Hint Rewrite @nth_default_nil @nth_default_cons : push_nth_default.
 
@@ -170,7 +172,11 @@ Section FoldRight.
   Lemma fold_right_ext (f g : A -> B -> B) b ls :
     (forall a b, In a ls -> f a b = g a b) ->
     fold_right f b ls = fold_right g b ls.
-  Admitted. (* TODO *)
+  Proof.
+    intro Hfg.
+    induction ls; cbn [fold_right];
+      rewrite ?IHls, ?Hfg by solver; solver.
+  Qed.
 End FoldRight.
 
 Section FoldLeft.
@@ -190,10 +196,17 @@ End FoldLeft.
 Section FirstnSkipn.
   Context {A : Type}.
 
-  Lemma firstn_snoc i ls d :
-    i < length ls ->
-    @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
-  Admitted. (* TODO *)
+  Lemma firstn_snoc ls d :
+    forall i,
+      i < length ls ->
+      @firstn A (S i) ls = firstn i ls ++ (nth_default d ls i :: nil).
+  Proof.
+    induction ls; intros;
+      autorewrite with push_nth_default push_length in *; [solver|].
+    cbn [firstn]. destruct i; [reflexivity|].
+    rewrite IHls by solver.
+    reflexivity.
+  Qed.
 
   Lemma in_firstn (a : A) ls : forall i, In a (firstn i ls) -> In a ls.
   Proof.


### PR DESCRIPTION
On top of #44 

This PR proves the remaining admitted lemmas left over from the `mm_map_root` proof that have to do with either low-level functions in `mm.c` or general, non-Hafnium-specific properties of binary numbers and lists. It also involves some nice proof automation for binary numbers, which simplifies the existing `mm.c` proofs.

Note that some of the code, especially in `Util/BinNat.v`, is just moved around, not added/deleted. This was because, in some cases, admitted lemmas were easier to prove using properties that had already been proven later in the file; I moved those properties above the admitted lemmas so that I could use them.