### PR TITLE
Tweak the framework for reasoning about pointers

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -3,6 +3,7 @@ src/AbstractModel.v
 src/Concrete/Datatypes.v
 src/Concrete/Model.v
 src/Concrete/Notations.v
+src/Concrete/PointerLocations.v
 src/Concrete/State.v
 src/Concrete/StateProofs.v
 src/Util/BinNat.v

--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -124,8 +124,10 @@ Section Abstract.
     {
       (* accessible_by is a function from address to list of entity IDs *)
       accessible_by : addr -> list entity_id;
-      (* owned_by is a function from address to list of entity IDs *)
-      owned_by : addr -> entity_id;
+      (* owned_by is a function from address to list of entity IDs -- only
+         single-element lists are considered valid, but for intermediate steps
+         we leave other lengths representable *)
+      owned_by : addr -> list entity_id;
     }.
 
   (*** The following definitions describe some basic operations on the abstract
@@ -186,7 +188,7 @@ Section Abstract.
                      if addr_eq_dec a a'
                      then
                        (* a = a'; to_id is the owner *)
-                       to_id
+                       [to_id]
                      else
                        (* a != a'; get the owner from the old state*)
                        owned_by a')
@@ -218,7 +220,7 @@ Section Abstract.
         {s : abstract_state} (id : entity_id) (a : addr) :=
     accessible_by a = [id].
   Local Definition owns {s : abstract_state} (id : entity_id) (a : addr) :=
-    owned_by a = id.
+    In id (owned_by a).
 
   (* tell [autounfold] to unfold these definitions *)
   Hint Unfold has_access has_exclusive_access owns.
@@ -248,7 +250,7 @@ Section Abstract.
           {|
             (* only the owner has access *)
             accessible_by := fun a => [owned_by_init a];
-            owned_by := owned_by_init;
+            owned_by := fun a => [owned_by_init a];
           |}
 
   (* a VM can give memory it owns to another VM *)

--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -317,6 +317,8 @@ Section Abstract.
     /\ (forall (vid : vm_id) (a : addr), owns vid a -> In vid vms)
     (* ...and at least one entity always has access to memory *)
     /\ (forall a, exists (e : entity_id), has_access e a)
+    (* ...and memory is always owned by exactly one VM *)
+    /\ (forall a, length (owned_by a) = 1)
     (* ...and memory is accessible by at most 2 VMs *)
     /\ (forall a, length (accessible_by a) <= 2)
     (* ...and no one has access to Hafnium's memory but Hafnium (id = [hid]) *)

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -24,15 +24,6 @@ Require Import Hafnium.Concrete.Assumptions.Mpool.
 Require Import Hafnium.Concrete.Api.Implementation.
 Require Import Hafnium.Concrete.MM.Proofs.
 
-Lemma api_clear_memory_valid
-      {cp : concrete_params} (conc : concrete_state) begin end_ ppool :
-  is_valid conc ->
-  let conc' := snd (fst (api_clear_memory conc begin end_ ppool)) in
-  is_valid conc'.
-Proof.
-  tauto. (* N.B. this proof is trivial because is_valid isn't yet filled in *)
-Qed.
-
 Lemma api_clear_memory_represents
       {ap : @abstract_state_parameters paddr_t nat} {cp : concrete_params}
       {cp_ok : params_valid}
@@ -54,16 +45,6 @@ Proof.
          | _ => apply mm_identity_map_represents
          | _ => solver
          end.
-Qed.
-
-Lemma api_share_memory_valid
-      {cp : concrete_params} (conc : concrete_state)
-      vid addr size share current :
-  is_valid conc ->
-  let conc' := snd (api_share_memory conc vid addr size share current) in
-  is_valid conc'.
-Proof.
-  tauto. (* N.B. this proof is trivial because is_valid isn't yet filled in *)
 Qed.
 
 Lemma api_share_memory_represents

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -15,7 +15,9 @@
  *)
 
 Require Import Coq.Lists.List.
+Require Import Coq.NArith.BinNat.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Notations.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
@@ -26,15 +28,6 @@ Require Import Hafnium.Concrete.MM.Datatypes.
      be considered part of the TCB, because the proofs rely on this transcription
      being a correct description of the lookup procedure. ***)
 
-(* index in each level of the page table (highest is root) *)
-Axiom index0 : uintpaddr_t -> nat.
-Axiom index1 : uintpaddr_t -> nat.
-Axiom index2 : uintpaddr_t -> nat.
-Axiom index3 : uintpaddr_t -> nat.
-
-(* in-page offset *)
-Axiom offset : uintpaddr_t -> nat.
-
 (* if we have a table PTE, we want to extract the address and get a
    ptable_pointer out of it *)
 Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
@@ -42,14 +35,59 @@ Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
 Definition get_entry (ptable : mm_page_table) (i : nat) : option pte_t :=
   nth_error ptable.(entries) i.
 
-Definition get_index (level : nat) (a : uintpaddr_t) : nat :=
-  match level with
-  | 0 => index0 a
-  | 1 => index1 a
-  | 2 => index2 a
-  | 3 => index3 a
-  | _ => 0 (* invalid level *)
+Axiom get_stage1_index : nat (* level *) -> uintpaddr_t -> nat.
+Axiom get_stage2_index : nat (* level *) -> uintpaddr_t -> nat.
+
+(* enum for stages 1 and 2 *)
+Inductive Stage : Type := Stage1 | Stage2.
+
+Definition get_index (s : Stage) (level : nat) (a : uintpaddr_t) : nat :=
+  match s with
+  | Stage1 => get_stage1_index level a
+  | Stage2 => get_stage2_index level a
   end.
+
+Definition max_level (s : Stage) : nat :=
+  match s with
+  | Stage1 => arch_mm_stage1_max_level
+  | Stage2 => arch_mm_stage2_max_level
+  end.
+
+Definition is_stage1 (s : Stage) : bool :=
+  match s with
+  | Stage1 => true
+  | Stage2 => false
+  end.
+
+Axiom stage1_index_of_uintvaddr :
+  forall (a : uintvaddr_t) (level : nat),
+    (* level offset for uintvaddr_t *)
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    (* convert a to uintpaddr_t *)
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level Stage1) ->
+    get_stage1_index level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+
+Axiom stage2_index_of_uintvaddr :
+  forall (a : uintvaddr_t) (level : nat),
+    (* level offset for uintvaddr_t *)
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    (* convert a to uintpaddr_t *)
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level Stage2) ->
+    get_stage2_index level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+
+(* TODO: this limits level to [S (max_level stage)] to allow for indices in
+   top-level lists of root tables -- is that the correct behavior? *)
+Lemma index_of_uintvaddr (a : uintvaddr_t) (level : nat) stage :
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level stage) ->
+    get_index stage level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+Proof.
+  destruct stage; cbv [get_index];
+    auto using stage1_index_of_uintvaddr, stage2_index_of_uintvaddr.
+Qed.
 
 (* N.B. the [option] here doesn't mean whether the entry is
    valid/present; rather, the lookup should return [Some] for any
@@ -59,11 +97,12 @@ Fixpoint page_lookup'
          (a : uintpaddr_t)
          (table : mm_page_table)
          (level : nat)
+         (s : Stage)
   : option pte_t :=
   match level with
   | 0 => None
   | S level' =>
-    match (get_entry table (get_index level a)) with
+    match (get_entry table (get_index s level a)) with
     | Some pte =>
       if (arch_mm_pte_is_table pte level)
       then
@@ -71,7 +110,7 @@ Fixpoint page_lookup'
         let next_ptr := ptable_pointer_from_address
                           (arch_mm_table_from_pte pte level) in
         let next_table := ptable_deref next_ptr in
-        page_lookup' ptable_deref a next_table level'
+        page_lookup' ptable_deref a next_table level' s
       else Some pte
     | None => None
     end
@@ -79,6 +118,6 @@ Fixpoint page_lookup'
 
 Definition page_lookup
            (ptable_deref : ptable_pointer -> mm_page_table)
-           (root_ptable : ptable_pointer)
+           (root_ptable : ptable_pointer) (s : Stage)
            (a : uintpaddr_t) : option pte_t :=
-  page_lookup' ptable_deref a (ptable_deref root_ptable) 4.
+  page_lookup' ptable_deref a (ptable_deref root_ptable) (max_level s) s.

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -58,22 +58,20 @@ Fixpoint page_lookup'
          (ptable_deref : ptable_pointer -> mm_page_table)
          (a : uintpaddr_t)
          (table : mm_page_table)
-         (* encode the level as (4 - level), so Coq knows this terminates *)
-         (lvls_to_go : nat)
+         (level : nat)
   : option pte_t :=
-  match lvls_to_go with
+  match level with
   | 0 => None
-  | S lvls_to_go' =>
-    let lvl := 4 - lvls_to_go in
-    match (get_entry table (get_index lvl a)) with
+  | S level' =>
+    match (get_entry table (get_index level a)) with
     | Some pte =>
-      if (arch_mm_pte_is_table pte lvl)
+      if (arch_mm_pte_is_table pte level)
       then
         (* follow the pointer to the next table *)
         let next_ptr := ptable_pointer_from_address
-                          (arch_mm_table_from_pte pte lvl) in
+                          (arch_mm_table_from_pte pte level) in
         let next_table := ptable_deref next_ptr in
-        page_lookup' ptable_deref a next_table lvls_to_go'
+        page_lookup' ptable_deref a next_table level'
       else Some pte
     | None => None
     end

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -26,10 +26,8 @@ Require Import Hafnium.Concrete.MM.Datatypes.
      be considered part of the TCB, because the proofs rely on this transcription
      being a correct description of the lookup procedure. ***)
 
-(* index in root-level page table *)
+(* index in each level of the page table (highest is root) *)
 Axiom index0 : uintpaddr_t -> nat.
-
-(* index in the other 3 levels of page table *)
 Axiom index1 : uintpaddr_t -> nat.
 Axiom index2 : uintpaddr_t -> nat.
 Axiom index3 : uintpaddr_t -> nat.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -22,6 +22,7 @@ Require Import Coq.omega.Omega.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.
+Require Import Hafnium.Concrete.PointerLocations.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.StateProofs.
 Require Import Hafnium.Util.BinNat.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -746,6 +746,13 @@ Section Proofs.
         apply N.lt_le_incl.
         apply mm_start_of_next_block_lt;
           auto using mm_entry_size_power_two. }
+      { (* is_valid s *)
+        apply represents_valid_concrete.
+        destruct abst; eexists. (* [destruct abst] is so [eexist] doesn't use [abst] *)
+        eapply reassign_pointer_represents; eauto; [ ].
+        apply has_uniform_attrs_reassign_pointer;
+          [ solve [auto using mm_map_level_noncircular] | ].
+        auto using mm_map_level_table_attrs_strong. }
       { (* is_begin_or_block_start start_begin begin  *)
         cbv [is_begin_or_block_start]. right.
         apply mm_start_of_next_block_is_start;

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -94,6 +94,19 @@ Section Proofs.
     break_match; subst; auto using in_eq, in_cons.
   Qed.
 
+  (* if [begin] is the start of the block at the level above, then we can freely
+     use a smaller address for [begin], because [has_uniform_attrs] ignores
+     addresses outside of [table]'s range. *)
+  Lemma has_uniform_attrs_block_start
+        ptable_deref table level attrs begin end_ idxs :
+    is_start_of_block begin (mm_entry_size level) ->
+    address_matches_indices begin idxs ->
+    forall begin',
+      (begin' <= begin)%N ->
+      has_uniform_attrs ptable_deref idxs table (level - 1) attrs begin end_ ->
+      has_uniform_attrs ptable_deref idxs table (level - 1) attrs begin' end_.
+  Admitted.
+
   (*** Proofs about [mm_page_table_from_pa] ***)
 
   Lemma mm_page_table_from_pa_length t flags :
@@ -105,6 +118,14 @@ Section Proofs.
       eauto using correct_number_of_root_tables_stage1,
       correct_number_of_root_tables_stage2.
   Qed.
+
+  Lemma has_location_in_state_root root_level flags c t i :
+    is_root root_level flags ->
+    ptable_is_root t flags ->
+    i < length (mm_page_table_from_pa (root t)) ->
+    has_location_in_state c (nth_default_oobe (mm_page_table_from_pa (root t)) i) (cons i nil).
+  Admitted. (* TODO *)
+  Hint Resolve has_location_in_state_root.
 
   (*** Proofs about [mm_root_table_count] ***)
 
@@ -391,6 +412,11 @@ Section Proofs.
     { rewrite mm_level_end_start_of_next_block_previous; solver. }
   Qed.
 
+  Lemma address_matches_indices_root root_level a flags :
+    is_root root_level flags ->
+    address_matches_indices a (mm_index a root_level :: nil).
+  Admitted. (* TODO *)
+  Hint Resolve address_matches_indices_root.
 
   (*** Proofs about [mm_free_page_pte] ***)
 
@@ -466,28 +492,16 @@ Section Proofs.
   Qed.
 
   Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level
-        flags ppool :
+        flags ppool ptr idxs :
     let ret :=
         mm_map_level conc begin end_ pa attrs table (level-1) flags ppool in
     let success := fst (fst (fst ret)) in
-    let table := snd (fst (fst ret)) in
+    let new_table := snd (fst (fst ret)) in
     let conc' := snd (fst ret) in
     let ppool' := snd ret in
-    has_uniform_attrs conc.(ptable_deref) table (level - 1) attrs begin end_.
-  Admitted.
-
-  (* TODO: move *)
-  (* TODO: has_uniform_attrs needs to know what the address of the start of its
-     block is -- otherwise it won't properly ignore out-of-range addresses *)
-  (* if [begin] is the start of the block at the level above, then we can freely
-     use a smaller address for [begin], because [has_uniform_attrs] ignores
-     addresses outside of [table]'s range. *)
-  Lemma has_uniform_attrs_block_start ptable_deref table level attrs begin end_ :
-    is_start_of_block begin (mm_entry_size level) ->
-    forall begin',
-      (begin' <= begin)%N ->
-      has_uniform_attrs ptable_deref table (level - 1) attrs begin end_ ->
-      has_uniform_attrs ptable_deref table (level - 1) attrs begin' end_.
+    conc.(ptable_deref) ptr = table ->
+    has_location_in_state conc ptr idxs ->
+    has_uniform_attrs conc.(ptable_deref) idxs new_table (level - 1) attrs begin end_.
   Admitted.
 
   Lemma mm_map_level_noncircular c begin end_ pa attrs ptr level flags ppool :
@@ -748,12 +762,13 @@ Section Proofs.
         apply mm_start_of_next_block_lt;
           auto using mm_entry_size_power_two. }
       { (* is_valid s *)
+        cbv [table_index_expression] in *; simplify; [ ].
         apply represents_valid_concrete.
         destruct abst; eexists. (* [destruct abst] is so [eexist] doesn't use [abst] *)
         eapply reassign_pointer_represents; eauto; [ ].
         apply has_uniform_attrs_reassign_pointer;
           try auto using mm_map_level_noncircular; try solver; [ ].
-        auto using mm_map_level_table_attrs. }
+        eauto using mm_map_level_table_attrs. }
       { (* is_begin_or_block_start start_begin begin  *)
         cbv [is_begin_or_block_start]. right.
         apply mm_start_of_next_block_is_start;
@@ -776,7 +791,6 @@ Section Proofs.
           by (autorewrite with push_length; lia).
         rewrite fold_left_app.
         cbn [fold_left].
-        cbv [nth_default_oobe ptable_pointer_oobe oob_value].
 
         (* swap out starting concrete state for current one *)
         match goal with
@@ -790,16 +804,16 @@ Section Proofs.
                      end
         end.
 
-        apply reassign_pointer_represents with (level := root_level - 1).
-        { assumption. }
-        { apply has_uniform_attrs_reassign_pointer;
+        eapply reassign_pointer_represents with (level := root_level - 1);
+          try solver; [ ].
+        apply has_uniform_attrs_reassign_pointer;
           try auto using mm_map_level_noncircular; try solver; [ ].
-          match goal with
-          | H : is_begin_or_block_start ?b ?x ?lvl |- _ =>
-            destruct H; [ subst; apply mm_map_level_table_attrs; solver | ]
-          end.
-          eapply has_uniform_attrs_block_start; try eassumption; [ ].
-          apply mm_map_level_table_attrs. } } }
+        match goal with
+        | H : is_begin_or_block_start ?b ?x ?lvl |- _ =>
+          destruct H; [ subst; eapply mm_map_level_table_attrs; solver | ]
+        end.
+        eapply has_uniform_attrs_block_start; try solver; [ ].
+        eapply mm_map_level_table_attrs; solver. } }
 
     { (* Subgoal 2 : invariant holds at start *)
       right.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -495,7 +495,7 @@ Section Proofs.
     let ret := mm_map_level
                  c begin end_ pa attrs (ptable_deref c ptr) level flags ppool in
     let table := snd (fst (fst ret)) in
-    ~ pointer_in_table (ptable_deref c) ptr table.
+    ~ pointer_in_table (ptable_deref c) ptr table level.
   Admitted. (* TODO *)
 
   (* TODO: might want a nicer reasoning framework for this *)
@@ -752,7 +752,7 @@ Section Proofs.
         destruct abst; eexists. (* [destruct abst] is so [eexist] doesn't use [abst] *)
         eapply reassign_pointer_represents; eauto; [ ].
         apply has_uniform_attrs_reassign_pointer;
-          [ solve [auto using mm_map_level_noncircular] | ].
+          try auto using mm_map_level_noncircular; try solver; [ ].
         auto using mm_map_level_table_attrs. }
       { (* is_begin_or_block_start start_begin begin  *)
         cbv [is_begin_or_block_start]. right.
@@ -793,7 +793,7 @@ Section Proofs.
         apply reassign_pointer_represents with (level := root_level - 1).
         { assumption. }
         { apply has_uniform_attrs_reassign_pointer;
-            [ solve [auto using mm_map_level_noncircular] | ].
+          try auto using mm_map_level_noncircular; try solver; [ ].
           match goal with
           | H : is_begin_or_block_start ?b ?x ?lvl |- _ =>
             destruct H; [ subst; apply mm_map_level_table_attrs; solver | ]

--- a/coq-verification/src/Concrete/PointerLocations.v
+++ b/coq-verification/src/Concrete/PointerLocations.v
@@ -1,0 +1,77 @@
+(*
+ * Copyright 2019 Jade Philipoom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *)
+
+Require Import Coq.Lists.List.
+Require Import Coq.Arith.PeanoNat.
+Require Import Coq.NArith.BinNat.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.ArchMM.
+Require Import Hafnium.Concrete.Assumptions.Constants.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Mpool.
+Require Import Hafnium.Concrete.Assumptions.PageTables.
+Require Import Hafnium.Concrete.MM.Datatypes.
+
+Section PointerLocations.
+  Context (ptable_deref : ptable_pointer -> mm_page_table).
+
+  (* We haven't formalized anywhere that pointers don't repeat, so we return a
+     list of all locations where the provided pointer exists even though we
+     expect there is only one. *)
+  Fixpoint index_sequences_to_pointer''
+           (ptr : ptable_pointer) (root : ptable_pointer) (lvls_to_go : nat)
+    : list (list nat) :=
+    match lvls_to_go with
+    | 0 => nil
+    | S lvls_to_go' =>
+      let lvl := 4 - lvls_to_go in
+      if ptable_pointer_eq_dec root ptr
+      then cons nil nil
+      else
+        let ptable := ptable_deref root in
+        flat_map
+          (fun index =>
+             match get_entry ptable index with
+             | Some pte =>
+               if arch_mm_pte_is_table pte lvl
+               then
+                 let next_root :=
+                     ptable_pointer_from_address
+                       (arch_mm_table_from_pte pte lvl) in
+                 map
+                   (cons index)
+                   (index_sequences_to_pointer'' ptr next_root lvls_to_go')
+               else nil
+             | None => nil
+             end)
+          (seq 0 (length ptable.(entries)))
+    end.
+  Fixpoint index_sequences_to_pointer'
+           (ptr : ptable_pointer) (root_index : nat)
+           (root_ptrs : list ptable_pointer) : list (list nat) :=
+    match root_ptrs with
+    | nil => nil
+    | cons root_ptr root_ptrs' =>
+      (map (cons root_index)
+           (index_sequences_to_pointer'' ptr root_ptr 4))
+        ++ index_sequences_to_pointer' ptr (S root_index) root_ptrs'
+    end.
+  Definition index_sequences_to_pointer
+           (ptr : ptable_pointer) (root_ptable : mm_ptable) :=
+    index_sequences_to_pointer'
+      ptr 0 (ptr_from_va (va_from_pa root_ptable.(root))).
+End PointerLocations.

--- a/coq-verification/src/Concrete/PointerLocations.v
+++ b/coq-verification/src/Concrete/PointerLocations.v
@@ -29,6 +29,9 @@ Require Import Hafnium.Concrete.MM.Datatypes.
 Section PointerLocations.
   Context (ptable_deref : ptable_pointer -> mm_page_table).
 
+  (* TODO: change everything everywhere about "lvls_to_go" -- it is based on the
+     incorrect understanding that the root is level 0, when really it's level 4
+     and the levels *decrease* as we go deeper *)
   (* We haven't formalized anywhere that pointers don't repeat, so we return a
      list of all locations where the provided pointer exists even though we
      expect there is only one. *)

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -20,6 +20,7 @@ Require Import Coq.NArith.BinNat.
 Require Import Hafnium.AbstractModel.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.
+Require Import Hafnium.Concrete.PointerLocations.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
@@ -83,14 +84,21 @@ Class params_valid {cp : concrete_params} :=
         = arch_mm_stage2_root_table_count
   }.
 
+Definition all_root_ptables {cp : concrete_params} : list mm_ptable :=
+  hafnium_ptable :: map vm_ptable vms.
+
+Definition all_root_ptable_pointers {cp : concrete_params}
+  : list ptable_pointer := hafnium_root_tables ++ flat_map vm_root_tables vms.
+
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
+  locations_exclusive s.(ptable_deref) all_root_ptables s.(api_page_pool)
   (* Possible constraints:
         - Block PTEs have the valid bit set
         - page tables have a constant size
         - page table indices are always below page table size
         - vm_id corresponds to a VM's place in the vms list
    *)
-  True.
+  .
 
 Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=
   find (fun v => (v.(vm_id) =? vid)) vms.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -148,11 +148,11 @@ Definition represents
   /\ (forall (a : paddr_t),
          In (inr hid) (abst.(accessible_by) a) <-> conc.(haf_page_valid) a)
   /\ (forall (vid : nat) (a : paddr_t),
-         abst.(owned_by) a = inl vid <->
+         In (inl vid) (abst.(owned_by) a) <->
          (exists v : vm,
              vm_find vid = Some v /\ conc.(vm_page_owned) v a))
   /\ (forall (a : paddr_t),
-         abst.(owned_by) a = inr hid <-> conc.(haf_page_owned) a)
+         In (inr hid) (abst.(owned_by) a) <-> conc.(haf_page_owned) a)
 .
 Definition represents_valid
            {ap : abstract_state_parameters}

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -91,7 +91,7 @@ Definition all_root_ptable_pointers {cp : concrete_params}
   : list ptable_pointer := hafnium_root_tables ++ flat_map vm_root_tables vms.
 
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
-  locations_exclusive s.(ptable_deref) all_root_ptables s.(api_page_pool)
+  locations_exclusive s.(ptable_deref) (map vm_ptable vms) hafnium_ptable s.(api_page_pool)
   (* Possible constraints:
         - Block PTEs have the valid bit set
         - page tables have a constant size
@@ -106,14 +106,14 @@ Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=
 Definition vm_page_valid (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr v.(vm_root_tables)
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage2 a.(pa_addr) = Some e
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Definition haf_page_valid
            {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr hafnium_root_tables
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage1 a.(pa_addr) = Some e
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Local Definition owned (mode : mode_t) : Prop :=
@@ -122,7 +122,7 @@ Local Definition owned (mode : mode_t) : Prop :=
 Definition vm_page_owned (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr v.(vm_root_tables)
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage2 a.(pa_addr) = Some e
     /\ forall lvl,
       owned (arch_mm_stage2_attrs_to_mode (arch_mm_pte_attrs e lvl)).
 
@@ -130,7 +130,7 @@ Definition haf_page_owned
            {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr hafnium_root_tables
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage1 a.(pa_addr) = Some e
     /\ forall lvl,
       owned (arch_mm_stage1_attrs_to_mode (arch_mm_pte_attrs e lvl)).
 

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -78,30 +78,24 @@ Section Proofs.
            end.
   Qed.
 
-  Fixpoint pointer_in_table'
+  Fixpoint pointer_in_table
              (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
-             (t : mm_page_table) (lvls_to_go : nat) : Prop :=
-    match lvls_to_go with
+             (t : mm_page_table) (level : nat) : Prop :=
+    match level with
     | 0 => False
-    | S lvls_to_go' =>
-      let lvl := 4 - lvls_to_go in
+    | S level' =>
       Exists
         (fun pte =>
-           if arch_mm_pte_is_table pte lvl
+           if arch_mm_pte_is_table pte level
            then
              let next_t_ptr :=
-                 ptable_pointer_from_address (arch_mm_table_from_pte pte lvl) in
+                 ptable_pointer_from_address (arch_mm_table_from_pte pte level) in
              if ptable_pointer_eq_dec ptr next_t_ptr
              then True
-             else pointer_in_table' deref ptr (deref next_t_ptr) lvls_to_go'
+             else pointer_in_table deref ptr (deref next_t_ptr) level'
            else False)
         t.(entries)
     end.
-
-  Definition pointer_in_table
-             (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
-             (t : mm_page_table) (level : nat) : Prop :=
-    pointer_in_table' deref ptr t (4 - level).
 
   Definition abstract_change_attrs (abst : abstract_state)
              (a : paddr_t) (e : entity_id) (owned valid : bool) :=

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -227,16 +227,17 @@ Section Proofs.
     has_location_in_state conc ptr idxs ->
     let conc' := conc.(reassign_pointer) ptr t in
     forall attrs level begin end_,
+      locations_exclusive
+        conc'.(ptable_deref) (map vm_ptable vms) hafnium_ptable conc.(api_page_pool) ->
       has_uniform_attrs
         conc'.(ptable_deref) idxs t level attrs begin end_ stage ->
       represents (abstract_reassign_pointer
                     abst conc ptr attrs begin end_)
                  conc'.
   Proof.
-    cbv [reassign_pointer represents].
-    cbv [is_valid].
+    cbv [reassign_pointer represents is_valid].
     cbv [vm_page_valid haf_page_valid vm_page_owned haf_page_owned].
-    cbn [ptable_deref].
+    cbn [ptable_deref api_page_pool].
     basics; try solver.
     (* TODO: 4 subgoals *)
   Admitted.
@@ -324,8 +325,8 @@ Section Proofs.
   (* TODO : fill in preconditions *)
   Lemma has_uniform_attrs_reassign_pointer
         c ptr new_table t level attrs begin end_ idxs stage :
-    is_valid c ->
-    ~ pointer_in_table (ptable_deref c) ptr t level ->
+    (* this precondition is so we know c doesn't show up in the new table *)
+    is_valid (reassign_pointer c ptr new_table) ->
     has_location_in_state c ptr idxs ->
     has_uniform_attrs (ptable_deref c) idxs t level attrs begin end_ stage ->
     has_uniform_attrs

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -55,6 +55,10 @@ Section Proofs.
     represents abst' conc.
   Admitted.
 
+  (* [represents] includes [is_valid] as one of its conditions *)
+  Lemma represents_valid_concrete abst conc : represents abst conc -> is_valid conc.
+  Proof. cbv [represents]; basics; auto. Qed.
+
   (* if the new table is the same as the old, abstract state doesn't change *)
   Lemma reassign_pointer_noop_represents conc ptr t abst :
     conc.(ptable_deref) ptr = t ->
@@ -110,15 +114,6 @@ Section Proofs.
   Definition deref_noncircular (c : concrete_state) : Prop :=
     forall ptr,
       ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr).
-
-  (* TODO : It's not clear that this definition is the correct approach. Consider
-     other ways to keep track of the fact that page tables don't have circular
-     references and don't use any locations in the freelist. *)
-  Definition pointers_ok (c : concrete_state) (ppool : mpool) : Prop :=
-    deref_noncircular c
-    /\ (forall ptr,
-           mpool_contains ppool ptr <->
-           (forall ptr2, ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr2))).
 
   (* We haven't formalized anywhere that pointers don't repeat, so we return a
      list of all locations where the provided pointer exists even though we

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -57,7 +57,7 @@ Section Proofs.
   Admitted.
 
   (* [represents] includes [is_valid] as one of its conditions *)
-  Lemma represents_valid_concrete abst conc : represents abst conc -> is_valid conc.
+  Lemma represents_valid_concrete conc : (exists abst, represents abst conc) -> is_valid conc.
   Proof. cbv [represents]; basics; auto. Qed.
 
   (* if the new table is the same as the old, abstract state doesn't change *)
@@ -76,12 +76,6 @@ Section Proofs.
                     [ | | solve[eauto] ]; eauto; [ ]
            end.
   Qed.
-
-  Definition all_root_ptables : list mm_ptable :=
-    hafnium_ptable :: map vm_ptable vms.
-
-  Definition all_root_ptable_pointers : list ptable_pointer :=
-    hafnium_root_tables ++ flat_map vm_root_tables vms.
 
   Fixpoint pointer_in_table'
              (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
@@ -111,10 +105,6 @@ Section Proofs.
              (deref : ptable_pointer -> mm_page_table) (ptr : ptable_pointer)
              (t : mm_page_table) : Prop :=
     Forall (pointer_in_table' deref ptr t) (seq 0 4).
-
-  Definition deref_noncircular (c : concrete_state) : Prop :=
-    forall ptr,
-      ~ pointer_in_table c.(ptable_deref) ptr (c.(ptable_deref) ptr).
 
   Definition abstract_change_attrs (abst : abstract_state)
              (a : paddr_t) (e : entity_id) (owned valid : bool) :=


### PR DESCRIPTION
In the proofs about `mm_map_level` and `represents`, I need to reason about the page table memory space. (To make explicit some confusing terminology -- in my proofs, `ptable_pointer` is not exactly a C pointer. It's an address in the memory space reserved for page tables, so there aren't multiple `ptable_pointer`s referencing the same thing.) I need the page table memory space to retain a few key properties:

1. Noncircularity - if I look at the page table referenced by a given `ptable_pointer`, then that `ptable_pointer` had better not show up again deeper in the same table.
2. Exclusivity - a `ptable_pointer` can either be free (contained in the mpool) or it can be in exactly one of the page tables. It can't be in a table and also in the mpool, and it can't be in two tables at once.
3. If a `ptable_pointer` is in one of the tables, then it can't appear in more than one location.

I had placeholders for these properties already in place, but I've given it some thought before I sink too much work into the proofs and decided on some modifications to the reasoning. I am going to sum up properties 1-3 above with reasoning about "pointer locations", which can be either positions within a table or just the mpool, and a statement in the concrete state's `is_valid` condition that says each `ptable_pointer` has at most one location. That way, all the needed memory properties are automatically kept track of via `is_valid` and I don't need to state them explicitly.

Most of the code changes in this PR are me moving a big definition from `StateProofs.v` to the new file `PointerLocations.v`, without substantial changes.