### PR TITLE
More fixing up page table logic

### DIFF
--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -124,8 +124,10 @@ Section Abstract.
     {
       (* accessible_by is a function from address to list of entity IDs *)
       accessible_by : addr -> list entity_id;
-      (* owned_by is a function from address to list of entity IDs *)
-      owned_by : addr -> entity_id;
+      (* owned_by is a function from address to list of entity IDs -- only
+         single-element lists are considered valid, but for intermediate steps
+         we leave other lengths representable *)
+      owned_by : addr -> list entity_id;
     }.
 
   (*** The following definitions describe some basic operations on the abstract
@@ -186,7 +188,7 @@ Section Abstract.
                      if addr_eq_dec a a'
                      then
                        (* a = a'; to_id is the owner *)
-                       to_id
+                       [to_id]
                      else
                        (* a != a'; get the owner from the old state*)
                        owned_by a')
@@ -218,7 +220,7 @@ Section Abstract.
         {s : abstract_state} (id : entity_id) (a : addr) :=
     accessible_by a = [id].
   Local Definition owns {s : abstract_state} (id : entity_id) (a : addr) :=
-    owned_by a = id.
+    In id (owned_by a).
 
   (* tell [autounfold] to unfold these definitions *)
   Hint Unfold has_access has_exclusive_access owns.
@@ -248,7 +250,7 @@ Section Abstract.
           {|
             (* only the owner has access *)
             accessible_by := fun a => [owned_by_init a];
-            owned_by := owned_by_init;
+            owned_by := fun a => [owned_by_init a];
           |}
 
   (* a VM can give memory it owns to another VM *)

--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -317,6 +317,8 @@ Section Abstract.
     /\ (forall (vid : vm_id) (a : addr), owns vid a -> In vid vms)
     (* ...and at least one entity always has access to memory *)
     /\ (forall a, exists (e : entity_id), has_access e a)
+    (* ...and memory is always owned by exactly one VM *)
+    /\ (forall a, length (owned_by a) = 1)
     (* ...and memory is accessible by at most 2 VMs *)
     /\ (forall a, length (accessible_by a) <= 2)
     (* ...and no one has access to Hafnium's memory but Hafnium (id = [hid]) *)

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -15,7 +15,9 @@
  *)
 
 Require Import Coq.Lists.List.
+Require Import Coq.NArith.BinNat.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Notations.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
@@ -26,15 +28,6 @@ Require Import Hafnium.Concrete.MM.Datatypes.
      be considered part of the TCB, because the proofs rely on this transcription
      being a correct description of the lookup procedure. ***)
 
-(* index in each level of the page table (highest is root) *)
-Axiom index0 : uintpaddr_t -> nat.
-Axiom index1 : uintpaddr_t -> nat.
-Axiom index2 : uintpaddr_t -> nat.
-Axiom index3 : uintpaddr_t -> nat.
-
-(* in-page offset *)
-Axiom offset : uintpaddr_t -> nat.
-
 (* if we have a table PTE, we want to extract the address and get a
    ptable_pointer out of it *)
 Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
@@ -42,14 +35,59 @@ Axiom ptable_pointer_from_address : paddr_t -> ptable_pointer.
 Definition get_entry (ptable : mm_page_table) (i : nat) : option pte_t :=
   nth_error ptable.(entries) i.
 
-Definition get_index (level : nat) (a : uintpaddr_t) : nat :=
-  match level with
-  | 0 => index0 a
-  | 1 => index1 a
-  | 2 => index2 a
-  | 3 => index3 a
-  | _ => 0 (* invalid level *)
+Axiom get_stage1_index : nat (* level *) -> uintpaddr_t -> nat.
+Axiom get_stage2_index : nat (* level *) -> uintpaddr_t -> nat.
+
+(* enum for stages 1 and 2 *)
+Inductive Stage : Type := Stage1 | Stage2.
+
+Definition get_index (s : Stage) (level : nat) (a : uintpaddr_t) : nat :=
+  match s with
+  | Stage1 => get_stage1_index level a
+  | Stage2 => get_stage2_index level a
   end.
+
+Definition max_level (s : Stage) : nat :=
+  match s with
+  | Stage1 => arch_mm_stage1_max_level
+  | Stage2 => arch_mm_stage2_max_level
+  end.
+
+Definition is_stage1 (s : Stage) : bool :=
+  match s with
+  | Stage1 => true
+  | Stage2 => false
+  end.
+
+Axiom stage1_index_of_uintvaddr :
+  forall (a : uintvaddr_t) (level : nat),
+    (* level offset for uintvaddr_t *)
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    (* convert a to uintpaddr_t *)
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level Stage1) ->
+    get_stage1_index level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+
+Axiom stage2_index_of_uintvaddr :
+  forall (a : uintvaddr_t) (level : nat),
+    (* level offset for uintvaddr_t *)
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    (* convert a to uintpaddr_t *)
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level Stage2) ->
+    get_stage2_index level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+
+(* TODO: this limits level to [S (max_level stage)] to allow for indices in
+   top-level lists of root tables -- is that the correct behavior? *)
+Lemma index_of_uintvaddr (a : uintvaddr_t) (level : nat) stage :
+    let offset := (PAGE_BITS + level * PAGE_LEVEL_BITS)%N in
+    let b : uintpaddr_t := pa_addr (pa_from_va (va_init a)) in
+    level <= S (max_level stage) ->
+    get_index stage level b = N.to_nat ((a / 2 ^ offset) mod 2 ^ PAGE_LEVEL_BITS).
+Proof.
+  destruct stage; cbv [get_index];
+    auto using stage1_index_of_uintvaddr, stage2_index_of_uintvaddr.
+Qed.
 
 (* N.B. the [option] here doesn't mean whether the entry is
    valid/present; rather, the lookup should return [Some] for any
@@ -59,11 +97,12 @@ Fixpoint page_lookup'
          (a : uintpaddr_t)
          (table : mm_page_table)
          (level : nat)
+         (s : Stage)
   : option pte_t :=
   match level with
   | 0 => None
   | S level' =>
-    match (get_entry table (get_index level a)) with
+    match (get_entry table (get_index s level a)) with
     | Some pte =>
       if (arch_mm_pte_is_table pte level)
       then
@@ -71,7 +110,7 @@ Fixpoint page_lookup'
         let next_ptr := ptable_pointer_from_address
                           (arch_mm_table_from_pte pte level) in
         let next_table := ptable_deref next_ptr in
-        page_lookup' ptable_deref a next_table level'
+        page_lookup' ptable_deref a next_table level' s
       else Some pte
     | None => None
     end
@@ -79,6 +118,6 @@ Fixpoint page_lookup'
 
 Definition page_lookup
            (ptable_deref : ptable_pointer -> mm_page_table)
-           (root_ptable : ptable_pointer)
+           (root_ptable : ptable_pointer) (s : Stage)
            (a : uintpaddr_t) : option pte_t :=
-  page_lookup' ptable_deref a (ptable_deref root_ptable) 4.
+  page_lookup' ptable_deref a (ptable_deref root_ptable) (max_level s) s.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -148,11 +148,11 @@ Definition represents
   /\ (forall (a : paddr_t),
          In (inr hid) (abst.(accessible_by) a) <-> conc.(haf_page_valid) a)
   /\ (forall (vid : nat) (a : paddr_t),
-         abst.(owned_by) a = inl vid <->
+         In (inl vid) (abst.(owned_by) a) <->
          (exists v : vm,
              vm_find vid = Some v /\ conc.(vm_page_owned) v a))
   /\ (forall (a : paddr_t),
-         abst.(owned_by) a = inr hid <-> conc.(haf_page_owned) a)
+         In (inr hid) (abst.(owned_by) a) <-> conc.(haf_page_owned) a)
 .
 Definition represents_valid
            {ap : abstract_state_parameters}

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -91,7 +91,7 @@ Definition all_root_ptable_pointers {cp : concrete_params}
   : list ptable_pointer := hafnium_root_tables ++ flat_map vm_root_tables vms.
 
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
-  locations_exclusive s.(ptable_deref) all_root_ptables s.(api_page_pool)
+  locations_exclusive s.(ptable_deref) (map vm_ptable vms) hafnium_ptable s.(api_page_pool)
   (* Possible constraints:
         - Block PTEs have the valid bit set
         - page tables have a constant size
@@ -106,14 +106,14 @@ Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=
 Definition vm_page_valid (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr v.(vm_root_tables)
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage2 a.(pa_addr) = Some e
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Definition haf_page_valid
            {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr hafnium_root_tables
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage1 a.(pa_addr) = Some e
     /\ forall lvl, arch_mm_pte_is_valid e lvl = true.
 
 Local Definition owned (mode : mode_t) : Prop :=
@@ -122,7 +122,7 @@ Local Definition owned (mode : mode_t) : Prop :=
 Definition vm_page_owned (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr v.(vm_root_tables)
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage2 a.(pa_addr) = Some e
     /\ forall lvl,
       owned (arch_mm_stage2_attrs_to_mode (arch_mm_pte_attrs e lvl)).
 
@@ -130,7 +130,7 @@ Definition haf_page_owned
            {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
   exists (e : pte_t) (root_ptr : ptable_pointer),
     In root_ptr hafnium_root_tables
-    /\ page_lookup s.(ptable_deref) root_ptr a.(pa_addr) = Some e
+    /\ page_lookup s.(ptable_deref) root_ptr Stage1 a.(pa_addr) = Some e
     /\ forall lvl,
       owned (arch_mm_stage1_attrs_to_mode (arch_mm_pte_attrs e lvl)).
 

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -227,16 +227,17 @@ Section Proofs.
     has_location_in_state conc ptr idxs ->
     let conc' := conc.(reassign_pointer) ptr t in
     forall attrs level begin end_,
+      locations_exclusive
+        conc'.(ptable_deref) (map vm_ptable vms) hafnium_ptable conc.(api_page_pool) ->
       has_uniform_attrs
         conc'.(ptable_deref) idxs t level attrs begin end_ stage ->
       represents (abstract_reassign_pointer
                     abst conc ptr attrs begin end_)
                  conc'.
   Proof.
-    cbv [reassign_pointer represents].
-    cbv [is_valid].
+    cbv [reassign_pointer represents is_valid].
     cbv [vm_page_valid haf_page_valid vm_page_owned haf_page_owned].
-    cbn [ptable_deref].
+    cbn [ptable_deref api_page_pool].
     basics; try solver.
     (* TODO: 4 subgoals *)
   Admitted.
@@ -324,8 +325,8 @@ Section Proofs.
   (* TODO : fill in preconditions *)
   Lemma has_uniform_attrs_reassign_pointer
         c ptr new_table t level attrs begin end_ idxs stage :
-    is_valid c ->
-    ~ pointer_in_table (ptable_deref c) ptr t level ->
+    (* this precondition is so we know c doesn't show up in the new table *)
+    is_valid (reassign_pointer c ptr new_table) ->
     has_location_in_state c ptr idxs ->
     has_uniform_attrs (ptable_deref c) idxs t level attrs begin end_ stage ->
     has_uniform_attrs


### PR DESCRIPTION
On top of #47 

Instead of hard-coding the number of levels a page table has, allow for different stages to have different numbers of levels. This meant adding a `stage` argument to `get_index`, and threading that argument through lots of other definitions. Finally, I also added a precondition to `mm_map_level_table_attrs` saying that `level <= max_level` for the given stage, and proved that precondition in the `mm_map_root` proof with the help of a couple new lemmas.