### PR TITLE
Starting state-change-related proofs

### DIFF
--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -124,8 +124,10 @@ Section Abstract.
     {
       (* accessible_by is a function from address to list of entity IDs *)
       accessible_by : addr -> list entity_id;
-      (* owned_by is a function from address to list of entity IDs *)
-      owned_by : addr -> entity_id;
+      (* owned_by is a function from address to list of entity IDs -- only
+         single-element lists are considered valid, but for intermediate steps
+         we leave other lengths representable *)
+      owned_by : addr -> list entity_id;
     }.
 
   (*** The following definitions describe some basic operations on the abstract
@@ -186,7 +188,7 @@ Section Abstract.
                      if addr_eq_dec a a'
                      then
                        (* a = a'; to_id is the owner *)
-                       to_id
+                       [to_id]
                      else
                        (* a != a'; get the owner from the old state*)
                        owned_by a')
@@ -218,7 +220,7 @@ Section Abstract.
         {s : abstract_state} (id : entity_id) (a : addr) :=
     accessible_by a = [id].
   Local Definition owns {s : abstract_state} (id : entity_id) (a : addr) :=
-    owned_by a = id.
+    In id (owned_by a).
 
   (* tell [autounfold] to unfold these definitions *)
   Hint Unfold has_access has_exclusive_access owns.
@@ -248,7 +250,7 @@ Section Abstract.
           {|
             (* only the owner has access *)
             accessible_by := fun a => [owned_by_init a];
-            owned_by := owned_by_init;
+            owned_by := fun a => [owned_by_init a];
           |}
 
   (* a VM can give memory it owns to another VM *)

--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -317,6 +317,8 @@ Section Abstract.
     /\ (forall (vid : vm_id) (a : addr), owns vid a -> In vid vms)
     (* ...and at least one entity always has access to memory *)
     /\ (forall a, exists (e : entity_id), has_access e a)
+    (* ...and memory is always owned by exactly one VM *)
+    /\ (forall a, length (owned_by a) = 1)
     (* ...and memory is accessible by at most 2 VMs *)
     /\ (forall a, length (accessible_by a) <= 2)
     (* ...and no one has access to Hafnium's memory but Hafnium (id = [hid]) *)

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -148,11 +148,11 @@ Definition represents
   /\ (forall (a : paddr_t),
          In (inr hid) (abst.(accessible_by) a) <-> conc.(haf_page_valid) a)
   /\ (forall (vid : nat) (a : paddr_t),
-         abst.(owned_by) a = inl vid <->
+         In (inl vid) (abst.(owned_by) a) <->
          (exists v : vm,
              vm_find vid = Some v /\ conc.(vm_page_owned) v a))
   /\ (forall (a : paddr_t),
-         abst.(owned_by) a = inr hid <-> conc.(haf_page_owned) a)
+         In (inr hid) (abst.(owned_by) a) <-> conc.(haf_page_owned) a)
 .
 Definition represents_valid
            {ap : abstract_state_parameters}

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -227,16 +227,17 @@ Section Proofs.
     has_location_in_state conc ptr idxs ->
     let conc' := conc.(reassign_pointer) ptr t in
     forall attrs level begin end_,
+      locations_exclusive
+        conc'.(ptable_deref) (map vm_ptable vms) hafnium_ptable conc.(api_page_pool) ->
       has_uniform_attrs
         conc'.(ptable_deref) idxs t level attrs begin end_ stage ->
       represents (abstract_reassign_pointer
                     abst conc ptr attrs begin end_)
                  conc'.
   Proof.
-    cbv [reassign_pointer represents].
-    cbv [is_valid].
+    cbv [reassign_pointer represents is_valid].
     cbv [vm_page_valid haf_page_valid vm_page_owned haf_page_owned].
-    cbn [ptable_deref].
+    cbn [ptable_deref api_page_pool].
     basics; try solver.
     (* TODO: 4 subgoals *)
   Admitted.
@@ -324,8 +325,8 @@ Section Proofs.
   (* TODO : fill in preconditions *)
   Lemma has_uniform_attrs_reassign_pointer
         c ptr new_table t level attrs begin end_ idxs stage :
-    is_valid c ->
-    ~ pointer_in_table (ptable_deref c) ptr t level ->
+    (* this precondition is so we know c doesn't show up in the new table *)
+    is_valid (reassign_pointer c ptr new_table) ->
     has_location_in_state c ptr idxs ->
     has_uniform_attrs (ptable_deref c) idxs t level attrs begin end_ stage ->
     has_uniform_attrs


### PR DESCRIPTION
On top of #48 

This PR proves `abstract_reassign_pointer_trivial` and also tweaks some preconditions of the proofs in `StateProofs.v`. It also involves modifying the abstract state for the first time in a while, in order to make unowned or multiply-owned memory representable. Of course, `AbstractModel.is_valid` still precludes any memory being owned by any number of entities other than 1, and that's added to the system invariants to be sure. But, since we want to be able to modify the abstract state to match the concrete one, *even if the concrete state corresponds to an invalid abstract state*, it makes sense to allow the representation of invalid abstract states.

Best reviewed commit-by-commit.