### PR TITLE
Progress on proofs about state-changes

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -3,6 +3,7 @@ src/AbstractModel.v
 src/Concrete/Datatypes.v
 src/Concrete/Model.v
 src/Concrete/Notations.v
+src/Concrete/PageTablesWf.v
 src/Concrete/PointerLocations.v
 src/Concrete/State.v
 src/Concrete/StateProofs.v

--- a/coq-verification/src/AbstractModel.v
+++ b/coq-verification/src/AbstractModel.v
@@ -321,6 +321,8 @@ Section Abstract.
     /\ (forall a, length (owned_by a) = 1)
     (* ...and memory is accessible by at most 2 VMs *)
     /\ (forall a, length (accessible_by a) <= 2)
+    (* ...and the set of memory owned by Hafnium never changes *)
+    /\ (forall a, owns hid a <-> hafnium_reserved a = true)
     (* ...and no one has access to Hafnium's memory but Hafnium (id = [hid]) *)
     /\ (forall a, hafnium_reserved a = true ->
                   forall (id : entity_id), has_access id a -> id = inr hid).
@@ -359,7 +361,9 @@ Section Abstract.
                                         rewrite H end; solver]
              | H : forall a, length (accessible_by a) <= _
                               |- context [accessible_by ?a] => specialize (H a)
+             | H : context [_ <-> _] |- _ => apply H; solver
              | _ => eexists; cbn; repeat break_match; solver
+             | |- _ <-> _ => split
              | _ => solver
              end.
   Qed.

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -14,6 +14,7 @@
  * limitations under the License.
  *)
 
+Require Import Coq.NArith.BinNat.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Assumptions.Constants.
 Require Import Hafnium.Concrete.Assumptions.Datatypes.
@@ -76,3 +77,8 @@ Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 P
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
+(* arch_mm_pte_is_valid is true iff [ attrs & PTE_VALID != 0 ] *)
+Axiom is_valid_matches_flag :
+  forall pte level,
+    let attrs := arch_mm_pte_attrs pte level in
+    arch_mm_pte_is_valid pte level = negb (N.eqb (N.land attrs PTE_VALID) 0).

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -50,8 +50,6 @@ Axiom arch_mm_pte_attrs : pte_t -> level -> attributes.
 
 Axiom arch_mm_stage2_attrs_to_mode : attributes -> mode_t.
 
-Axiom arch_mm_stage1_attrs_to_mode : attributes -> mode_t.
-
 Axiom arch_mm_stage2_max_level : level.
 
 Axiom arch_mm_stage1_max_level : level.

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -76,3 +76,5 @@ Axiom arch_mm_combine_table_entry_attrs : attributes -> attributes -> attributes
 (* Assumptions about the properties of arch/mm.c *)
 Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
+Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
+Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.

--- a/coq-verification/src/Concrete/Assumptions/Constants.v
+++ b/coq-verification/src/Concrete/Assumptions/Constants.v
@@ -40,6 +40,7 @@ Axiom MM_PTE_PER_PAGE : nat.
 Axiom MM_MODE_R_index MM_MODE_W_index MM_MODE_X_index MM_MODE_INVALID_index
       MM_MODE_UNOWNED_index MM_MODE_SHARED_index : nat.
 Axiom MM_FLAG_STAGE1_index MM_FLAG_COMMIT_index MM_FLAG_UNMAP_index : nat.
+Axiom PTE_VALID_index : nat. (* valid bit for stage-1 attributes *)
 
 Definition index_to_N (i : nat) := N.shiftl 1 (N.of_nat i).
 
@@ -52,6 +53,7 @@ Definition MM_MODE_SHARED : N := index_to_N MM_MODE_SHARED_index.
 Definition MM_FLAG_STAGE1 : N := index_to_N MM_FLAG_STAGE1_index.
 Definition MM_FLAG_COMMIT : N := index_to_N MM_FLAG_COMMIT_index.
 Definition MM_FLAG_UNMAP : N := index_to_N MM_FLAG_UNMAP_index.
+Definition PTE_VALID : N := index_to_N PTE_VALID_index.
 
 (* assume that all indices are distinct from each other *)
 Axiom mm_modes_distinct :

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -118,6 +118,9 @@ Fixpoint page_lookup'
 
 Definition page_lookup
            (ptable_deref : ptable_pointer -> mm_page_table)
-           (root_ptable : ptable_pointer) (s : Stage)
+           (root_ptable : mm_ptable) (s : Stage)
            (a : uintpaddr_t) : option pte_t :=
-  page_lookup' ptable_deref a (ptable_deref root_ptable) (max_level s) s.
+  let root_tables := ptr_from_va (va_from_pa (root root_ptable)) in
+  let index := get_index s (max_level s + 1) a in
+  let table_ptr := nth_default null_pointer root_tables index in
+  page_lookup' ptable_deref a (ptable_deref table_ptr) (max_level s) s.

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -92,13 +92,14 @@ Qed.
 (* N.B. the [option] here doesn't mean whether the entry is
    valid/present; rather, the lookup should return [Some] for any
    valid input, but the PTE returned might be absent or invalid. *)
+(* Returns both the entry and the level *)
 Fixpoint page_lookup'
          (ptable_deref : ptable_pointer -> mm_page_table)
          (a : uintpaddr_t)
          (table : mm_page_table)
          (level : nat)
          (s : Stage)
-  : option pte_t :=
+  : option (pte_t * nat) :=
   match level with
   | 0 => None
   | S level' =>
@@ -111,7 +112,7 @@ Fixpoint page_lookup'
                           (arch_mm_table_from_pte pte level) in
         let next_table := ptable_deref next_ptr in
         page_lookup' ptable_deref a next_table level' s
-      else Some pte
+      else Some (pte, level)
     | None => None
     end
   end.
@@ -119,7 +120,7 @@ Fixpoint page_lookup'
 Definition page_lookup
            (ptable_deref : ptable_pointer -> mm_page_table)
            (root_ptable : mm_ptable) (s : Stage)
-           (a : uintpaddr_t) : option pte_t :=
+           (a : uintpaddr_t) : option (pte_t * nat) :=
   let root_tables := ptr_from_va (va_from_pa (root root_ptable)) in
   let index := get_index s (max_level s + 1) a in
   let table_ptr := nth_default null_pointer root_tables index in

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -105,6 +105,21 @@ Section Proofs.
     break_match; subst; auto using in_eq, in_cons.
   Qed.
 
+  Lemma root_matches_stage_from_flags t flags :
+    ptable_is_root t flags ->
+    root_ptable_matches_stage t (stage_from_flags flags).
+  Proof.
+    cbv [ptable_is_root stage_from_flags root_ptable_matches_stage].
+    break_match; solver.
+  Qed.
+  Hint Resolve root_matches_stage_from_flags.
+
+  Lemma max_level_pos stage : 0 < max_level stage.
+  Proof.
+    cbv [max_level]; destruct stage;
+      auto using stage1_max_level_pos, stage2_max_level_pos.
+  Qed.
+
   (* if [begin] is the start of the block at the level above, then we can freely
      use a smaller address for [begin], because [attrs_changed_in_range] ignores
      addresses outside of [table]'s range. *)
@@ -130,12 +145,62 @@ Section Proofs.
       correct_number_of_root_tables_stage2.
   Qed.
 
-  Lemma has_location_in_state_root root_level flags c t i :
-    is_root root_level flags ->
+  (* TODO : move *)
+  Lemma index_sequences_to_pointer''_root deref ptr level :
+    0 < level ->
+    In nil (index_sequences_to_pointer'' deref ptr ptr level).
+  Proof.
+    destruct level; [solver|]; intros.
+    cbn [index_sequences_to_pointer''].
+    break_match; solver.
+  Qed.
+
+  (* TODO : move *)
+  Lemma index_sequences_to_pointer'_nth_default deref root_list stage :
+    forall i j k,
+      i < length root_list ->
+      k = i + j ->
+      In (k :: nil)
+         (index_sequences_to_pointer'
+            deref (nth_default_oobe root_list i) j root_list stage).
+  Proof.
+    cbv [nth_default_oobe]. pose proof (max_level_pos stage).
+    induction root_list; destruct i; cbn [length index_sequences_to_pointer'];
+      repeat match goal with
+             | _ => progress basics
+             | _ => progress autorewrite with push_nth_default
+             | _ => rewrite Nat.add_0_l
+             | _ => apply in_or_app
+             | _ => left; apply in_map;
+                      solve [auto using index_sequences_to_pointer''_root]
+             | _ => right; apply IHroot_list; solver
+             | _ => solver
+             end.
+  Qed.
+
+  Lemma has_location_nth_default deref ppool flags root_ptable i :
+    i < length (mm_page_table_from_pa (root root_ptable)) ->
+    ptable_is_root root_ptable flags ->
+    has_location deref (map vm_ptable vms) hafnium_ptable ppool
+                 (nth_default_oobe (mm_page_table_from_pa (root root_ptable)) i)
+                 (table_loc ppool root_ptable (cons i nil)).
+  Proof.
+    cbv [ptable_is_root mm_page_table_from_pa]; intros; break_match; basics.
+    { apply has_table_loc_stage1. cbv [index_sequences_to_pointer].
+      apply index_sequences_to_pointer'_nth_default; solver. }
+    { apply has_table_loc_stage2; auto; [ ].
+      cbv [index_sequences_to_pointer].
+      apply index_sequences_to_pointer'_nth_default; solver. }
+  Qed.
+
+  Lemma has_location_in_state_root flags c t i :
     ptable_is_root t flags ->
     i < length (mm_page_table_from_pa (root t)) ->
     has_location_in_state c (nth_default_oobe (mm_page_table_from_pa (root t)) i) (cons i nil).
-  Admitted. (* TODO *)
+  Proof.
+    cbv [has_location_in_state]. intros; eexists.
+    eapply has_location_nth_default; eauto.
+  Qed.
   Hint Resolve has_location_in_state_root.
 
   (*** Proofs about [mm_max_level] ***)
@@ -693,37 +758,6 @@ Section Proofs.
              end.
   Qed.
 
-  (* TODO : move *)
-  Lemma has_location_nth_default deref ppool flags root_ptable i :
-    i < mm_root_table_count flags ->
-    ptable_is_root root_ptable flags ->
-    has_location deref (map vm_ptable vms) hafnium_ptable ppool
-                 (nth_default_oobe (mm_page_table_from_pa (root root_ptable)) i)
-                 (table_loc ppool root_ptable (cons i nil)).
-  Admitted. (* TODO *)
-
-  (* TODO : move *)
-  Lemma has_location_in_state_nth_default conc flags root_ptable i :
-    i < mm_root_table_count flags ->
-    ptable_is_root root_ptable flags ->
-    has_location_in_state
-      conc (nth_default_oobe (mm_page_table_from_pa (root root_ptable)) i)
-      (cons i nil).
-  Proof.
-    cbv [has_location_in_state]. intros; eexists.
-    eapply has_location_nth_default; eauto.
-  Qed.
-
-  (* TODO : move *)
-  Lemma root_matches_stage_from_flags t flags :
-    ptable_is_root t flags ->
-    root_ptable_matches_stage t (stage_from_flags flags).
-  Proof.
-    cbv [ptable_is_root stage_from_flags root_ptable_matches_stage].
-    break_match; solver.
-  Qed.
-  Hint Resolve root_matches_stage_from_flags.
-
   (* TODO:
      This proof says only that if success = true and commit = true
      then the abstract state changed. We need two more proofs for full
@@ -855,8 +889,7 @@ Section Proofs.
         apply represents_valid_concrete.
         destruct abst; eexists. (* [destruct abst] is so [eexist] doesn't use [abst] *)
         eapply reassign_pointer_represents; eauto; [ | | ].
-        { rewrite mm_page_table_from_pa_length with (flags:=flags) in * by eauto.
-          apply has_location_nth_default with (flags:=flags); eauto. }
+        { apply has_location_nth_default with (flags:=flags); eauto. }
         { apply mm_map_level_locations_exclusive; solver. }
         { eapply mm_map_level_table_attrs; solver. } }
       { (* is_begin_or_block_start start_begin begin  *)
@@ -894,19 +927,15 @@ Section Proofs.
                      end
         end.
 
-        rewrite mm_page_table_from_pa_length with (flags:=flags) in * by eauto.
         eapply reassign_pointer_represents with (level := root_level - 1);
           try apply has_location_nth_default with (flags:=flags);
           try apply mm_map_level_locations_exclusive; try solver; [ ].
         match goal with
         | H : is_begin_or_block_start ?b ?x ?lvl |- _ =>
-          destruct H; [ subst | ]
+          destruct H; [ subst; eapply mm_map_level_table_attrs; solver | ]
         end.
-        { eapply mm_map_level_table_attrs; try solver.
-          eapply has_location_in_state_nth_default; eauto. }
-        { eapply attrs_changed_in_range_block_start; try solver; [ ].
-          eapply mm_map_level_table_attrs; try solver; [ ].
-          eapply has_location_in_state_nth_default; eauto. } } }
+        eapply attrs_changed_in_range_block_start; try solver; [ ].
+        eapply mm_map_level_table_attrs; solver. } }
 
     { (* Subgoal 2 : invariant holds at start *)
       right.

--- a/coq-verification/src/Concrete/PageTablesWf.v
+++ b/coq-verification/src/Concrete/PageTablesWf.v
@@ -1,0 +1,118 @@
+(*
+ * Copyright 2019 Jade Philipoom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *)
+
+Require Import Coq.Lists.List.
+Require Import Coq.Arith.PeanoNat.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Util.Tactics.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.ArchMM.
+Require Import Hafnium.Concrete.Assumptions.Constants.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.PageTables.
+Require Import Hafnium.Concrete.MM.Datatypes.
+
+(* states that a table has the right number of entries at every level and doesn't
+   exceed the maximum number of levels *)
+(* TODO : could add max_block_level to this, and get the proof that tables don't
+   have blocks above level 2 *)
+Inductive page_table_wf (deref : ptable_pointer -> mm_page_table) (s : Stage)
+  : mm_page_table -> nat -> Prop :=
+| page_table_wf_last_level :
+    (* no table entries at next level down *)
+    forall (entries : list pte_t) (level : nat),
+      length entries = MM_PTE_PER_PAGE ->
+      level < max_level s ->
+      Forall (fun pte => arch_mm_pte_is_table pte level = false) entries ->
+      page_table_wf deref s {| entries := entries |} level
+| page_table_wf_step :
+    (* well-formed if the level below is also *)
+    forall (entries : list pte_t) (level : nat),
+      length entries = MM_PTE_PER_PAGE ->
+      level <= max_level s ->
+      Forall (fun pte =>
+                arch_mm_pte_is_table pte (S level) = true ->
+                let next_ptr := ptable_pointer_from_address
+                                  (arch_mm_table_from_pte pte (S level)) in
+                let next_table := deref next_ptr in
+                page_table_wf deref s next_table level) entries ->
+      page_table_wf deref s {| entries := entries |} (S level)
+.
+ 
+Definition root_ptable_wf deref (s : Stage) (root_ptable : mm_ptable) : Prop :=
+  let root_tables := ptr_from_va (va_from_pa (root root_ptable)) in
+  (length root_tables = root_table_count s
+   /\ Forall
+        (fun ptr => page_table_wf deref s (deref ptr) (max_level s))
+        root_tables).
+
+Definition address_wf (a : uintpaddr_t) (s : Stage) : Prop :=
+  (forall level, level <= max_level s -> get_index s level a < MM_PTE_PER_PAGE)
+  /\ (get_index s (max_level s + 1) a < root_table_count s).
+
+Lemma page_lookup'_ok deref s a :
+  forall level t,
+    address_wf a s ->
+    page_table_wf deref s t (pred level) ->
+    0 < level <= max_level s + 1->
+    page_lookup' deref a t level s <> None.
+Proof.
+  induction level; [|destruct (Nat.eq_dec level 0)]; basics;
+    match goal with
+    | H : address_wf _ _ |- _ => pose proof H; cbv [address_wf] in H
+    end;
+    repeat match goal with
+           | _ => progress basics
+           | _ => progress cbn [page_lookup']; cbv [get_entry]
+           | _ => progress cbn [Datatypes.entries] in *
+           | _ => progress rewrite <-pred_Sn in *
+           | H : page_table_wf _ _ _ 0 |- _ => invert H
+           | H : page_table_wf _ _ _ ?lvl
+             |- page_table_wf _ _ _ (Nat.pred ?lvl) => invert H
+           | H : (forall level, _ -> get_index _ level _ < _)
+             |- context [get_index _ ?lvl _] => specialize (H lvl ltac:(solver))
+           | H : Forall ?P ?ls, H' : In ?x ?ls |- _ =>
+             rewrite Forall_forall in H; pose proof H; specialize (H _ H')
+           | H : nth_error _ _ = None |- _ => apply nth_error_None in H
+           | H : nth_error _ _ = Some _ |- _ => apply nth_error_In in H
+           | _ => apply IHlevel
+           | H : page_table_wf _ _ _ _ |- _ =>
+             invert H; basics; cbn [Datatypes.entries] in *; solver
+           | _ => break_match
+           | _ => solver
+           end.
+Qed.
+
+Lemma page_lookup_ok deref root_ptable s a :
+  address_wf a s ->
+  root_ptable_wf deref s root_ptable ->
+  page_lookup deref root_ptable s a <> None.
+Proof.
+  cbv [page_lookup root_ptable_wf address_wf]; basics.
+  match goal with
+  | H : ?i < ?l, H' : length ?ls = ?l |- context [nth_error ?ls ?i] =>
+    pose proof H; rewrite <-H', <-nth_error_Some in H
+  end.
+  break_match; [|solver].
+  match goal with
+  | H : Forall _ ?ls, H' : nth_error ?ls ?i = Some _ |- _ =>
+    rewrite Forall_forall in H;
+      specialize (H _ (nth_error_In _ _ H'))
+  end.
+  rewrite Nat.add_1_r.
+  apply page_lookup'_ok;
+    cbv [address_wf]; basics; try solver.
+Qed.

--- a/coq-verification/src/Concrete/PageTablesWf.v
+++ b/coq-verification/src/Concrete/PageTablesWf.v
@@ -51,7 +51,7 @@ Inductive page_table_wf (deref : ptable_pointer -> mm_page_table) (s : Stage)
                 page_table_wf deref s next_table level) entries ->
       page_table_wf deref s {| entries := entries |} (S level)
 .
- 
+
 Definition root_ptable_wf deref (s : Stage) (root_ptable : mm_ptable) : Prop :=
   let root_tables := ptr_from_va (va_from_pa (root root_ptable)) in
   (length root_tables = root_table_count s

--- a/coq-verification/src/Concrete/PointerLocations.v
+++ b/coq-verification/src/Concrete/PointerLocations.v
@@ -109,7 +109,7 @@ Section PointerLocations.
         forall root_ptable idxs ptr,
           In root_ptable vm_ptables ->
           In idxs (index_sequences_to_pointer ptr root_ptable Stage2) ->
-          has_location ptr (table_loc ppool haf_ptable idxs)
+          has_location ptr (table_loc ppool root_ptable idxs)
     | has_mpool_loc :
         forall ptr,
           mpool_contains ppool ptr ->

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -92,7 +92,8 @@ Class params_valid {cp : concrete_params} :=
         In t (map vm_ptable vms) ->
         length (ptr_from_va (va_from_pa t.(root)))
         = arch_mm_stage2_root_table_count;
-    no_duplicate_ptables : NoDup all_root_ptables
+    no_duplicate_ptables : NoDup all_root_ptables;
+    no_duplicate_ids : NoDup (map vm_id vms)
   }.
 
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -130,18 +130,19 @@ Definition vm_page_owned {cp : concrete_params}
            (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=
   stage2_mode_has_value s v a MM_MODE_UNOWNED false.
 
-(* Stage-1 attributes don't have a specific bit for "owned". However, Hafnium
-   always owns all the memory it can access; its only shared memory is send/recv
-   buffers, which are shared with VMs but owned by Hafnium. So for Hafnium,
-   "owned" is equivalent to "accessible" or "valid". *)
+(* Stage-1 attributes don't have a specific bit for "owned". However, the set of
+   pages owned by Hafnium doesn't change over the course of the program, so we
+   can get it from the starting parameters. *)
 Definition haf_page_owned
-           {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
-  haf_page_valid s a.
+           {ap : @abstract_state_parameters paddr_t nat}
+           (s : concrete_state) (a : paddr_t) : Prop :=
+  hafnium_reserved a = true.
 
 Arguments owned_by {_} {_} _.
 Arguments accessible_by {_} {_} _.
 Definition represents
            {cp : concrete_params}
+           {ap : abstract_state_parameters}
            (abst : @abstract_state paddr_t nat)
            (conc : concrete_state) : Prop :=
   is_valid conc

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -100,7 +100,7 @@ Class params_valid {cp : concrete_params} :=
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
   locations_exclusive s.(ptable_deref) (map vm_ptable vms) hafnium_ptable s.(api_page_pool)
   /\ Forall (root_ptable_wf s.(ptable_deref) Stage2) (map vm_ptable vms)
-  /\ root_ptable_wf s.(ptable_deref) Stage1 hafnium_ptable 
+  /\ root_ptable_wf s.(ptable_deref) Stage1 hafnium_ptable
 .
 
 Definition vm_find {cp : concrete_params} (vid : nat) : option vm :=

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -378,29 +378,6 @@ Section Proofs.
       In e (owned_by new_abst a) <-> In e (owned_by abst a).
   Admitted. (* TODO *)
 
-  Lemma index_sequences_to_pointer_change_start deref ptr root_ptable stage t ppool :
-    In root_ptable all_root_ptables ->
-    locations_exclusive deref ppool ->
-    index_sequences_to_pointer
-      (fun ptr' : ptable_pointer => if ptable_pointer_eq_dec ptr ptr' then t else deref ptr')
-      ptr root_ptable stage = index_sequences_to_pointer deref ptr root_ptable stage.
-  Admitted.
-
-  (* states that if we change the ptable_deref function but only affect pointers
-     in the stage-1 table, then stage-2 lookups are unaltered *)
-  Lemma page_lookup_proper_stage2 deref1 deref2 root_ptable ppool a:
-    (* all pointers have at most 1 location *)
-    locations_exclusive deref1 ppool ->
-    (* root_ptable is a stage-2 table *)
-    In root_ptable (map vm_ptable vms) ->
-    (* forall pointers, if the pointer is NOT in the stage1 page table, then
-       deref1 is the same as deref2 *)
-    (forall ptr,
-        index_sequences_to_pointer deref1 ptr hafnium_ptable Stage1 = nil ->
-        deref1 ptr = deref2 ptr) ->
-      page_lookup deref1 root_ptable Stage2 a = page_lookup deref2 root_ptable Stage2 a.
-  Admitted. (* TODO *)
-
   Definition vm_page_table_unchanged deref1 deref2 v : Prop :=
     forall ptr,
       index_sequences_to_pointer deref1 ptr (vm_ptable v) Stage2 <> nil
@@ -933,6 +910,7 @@ Section Proofs.
 
   (* attrs_changed_in_range doesn't care if we reassign the pointer we started from *)
   (* TODO : fill in preconditions *)
+  (* TODO : currently unused; remove if not used in mm_map_level proofs *)
   Lemma attrs_changed_in_range_reassign_pointer
         c ptr new_table t level attrs begin end_ idxs stage :
     (* this precondition is so we know c doesn't show up in the new table *)

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -751,39 +751,23 @@ Section Proofs.
     { (* stage-1 [accessible_by] states match *)
       rewrite accessible_by_abstract_reassign_pointer_stage1 by eauto.
       process_represents;
-        cbv [haf_page_valid] in *; basics; cbn [ptable_deref] in *.
-      {
-        match goal with
-        | H : root_ptable_wf ?deref _ _
-          |- context [page_lookup ?deref ?t ?s ?a] =>
-          pose proof H; eapply page_lookup_ok in H; eauto; [ ];
-          case_eq (page_lookup deref t s a); basics; try solver; [ ]
-        end.
-        basics. destruct_tuples.
-        do 2 eexists; split; [solver|].
-        match goal with H :  In _ _ |- _ =>
-                        pose proof H; eapply changed_has_new_attrs in H;
-                          cbv [root_ptable_matches_stage]; try solver; [ ]
-        end.
-        basics. destruct_tuples.
-        cbv [stage1_valid] in *.
-        rewrite is_valid_matches_flag. solver. }
-      {
-        match goal with
-        | H : root_ptable_wf ?deref _ _
-          |- context [page_lookup ?deref ?t ?s ?a] =>
-          pose proof H; eapply page_lookup_ok in H; eauto; [ ];
-          case_eq (page_lookup deref t s a); basics; try solver; [ ]
-        end.
-        basics. destruct_tuples.
-        do 2 eexists; split; [solver|].
-        match goal with H :  In _ _ |- _ =>
-                        pose proof H; eapply changed_has_new_attrs in H;
-                          cbv [root_ptable_matches_stage]; try solver; [ ]
-        end.
-        basics. destruct_tuples.
-        cbv [stage1_valid] in *.
-        rewrite is_valid_matches_flag. solver. } }
+        cbv [haf_page_valid] in *; basics; cbn [ptable_deref] in *;
+          match goal with
+          | H : root_ptable_wf ?deref _ _
+            |- context [page_lookup ?deref ?t ?s ?a] =>
+            pose proof H; eapply page_lookup_ok in H; eauto; [ ];
+              case_eq (page_lookup deref t s a); basics; try solver; [ ]
+          end;
+          repeat match goal with
+                 | _ => progress basics
+                 | _ => progress destruct_tuples
+                 | H :  In _ _ |- _ =>
+                   eapply changed_has_new_attrs in H;
+                     cbv [root_ptable_matches_stage]; try solver; [ ]
+                 | _ => solver
+                 | _ => cbv [stage1_valid] in *; rewrite is_valid_matches_flag; solver
+                 | _ => do 2 eexists; split; [solver|]
+                 end. }
     { (* stage-2 [owned_by] states match *)
       rewrite owned_by_abstract_reassign_pointer_stage1 by eauto.
       process_represents. }

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -323,7 +323,7 @@ Section Proofs.
       then
         if stage1_valid attrs
         then e = inr hid \/ In e (accessible_by abst a)
-        else e <> inr hid /\ In e (accessible_by abst a) 
+        else e <> inr hid /\ In e (accessible_by abst a)
       else In e (accessible_by abst a).
   Admitted. (* TODO *)
 
@@ -752,7 +752,7 @@ Section Proofs.
       rewrite accessible_by_abstract_reassign_pointer_stage1 by eauto.
       process_represents;
         cbv [haf_page_valid] in *; basics; cbn [ptable_deref] in *.
-      { 
+      {
         match goal with
         | H : root_ptable_wf ?deref _ _
           |- context [page_lookup ?deref ?t ?s ?a] =>
@@ -768,7 +768,7 @@ Section Proofs.
         basics. destruct_tuples.
         cbv [stage1_valid] in *.
         rewrite is_valid_matches_flag. solver. }
-      { 
+      {
         match goal with
         | H : root_ptable_wf ?deref _ _
           |- context [page_lookup ?deref ?t ?s ?a] =>

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -23,6 +23,7 @@ Import ListNotations.
 (* perform inversion on list-based inductives in hypotheses *)
 Ltac invert_list_properties :=
   repeat match goal with
+         | H : NoDup (_ :: _) |- _ => invert H
          | H : Exists _ (_ :: _) |- _ => invert H
          | H : Exists _ [] |- _ => invert H
          | H : Forall _ (_ :: _) |- _ => invert H

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -136,6 +136,10 @@ Section NthDefault.
     nth_default d (a :: ls) (S i) = nth_default d ls i.
   Proof. reflexivity. Qed.
 
+  Lemma nth_default_cons_0 a ls :
+    nth_default d (a :: ls) 0 = a.
+  Proof. reflexivity. Qed.
+
   Lemma nth_default_in_bounds i ls :
     nth_default d ls i <> d -> i < length ls.
   Proof.
@@ -156,7 +160,8 @@ Section NthDefault.
     intros; rewrite nth_default_eq; auto using nth_In.
   Qed.
 End NthDefault.
-Hint Rewrite @nth_default_nil @nth_default_cons : push_nth_default.
+Hint Rewrite @nth_default_nil @nth_default_cons @nth_default_cons_0
+  : push_nth_default.
 
 Section FoldRight.
   Context {A B : Type}.
@@ -397,7 +402,7 @@ Definition nth_default_oobe
 (* populate the list_quals hint database *)
 Hint Resolve FOP_nil FOP_cons Forall_nil Forall_forall
   : list_quals.
-Hint Resolve in_or_app in_cons in_eq : list_quals.
+Hint Resolve in_or_app in_cons in_eq.
 
 (* simplify goals with list qualifiers *)
 Ltac simpl_list_qualifiers :=

--- a/coq-verification/src/Util/Tactics.v
+++ b/coq-verification/src/Util/Tactics.v
@@ -35,6 +35,13 @@ Ltac basics :=
          | H : inr _ = inr _ |- _ => invert H
          end.
 
+(* destruct tuples *)
+Ltac destruct_tuples :=
+  repeat match goal with
+         | _ => progress cbn [fst snd] in *
+         | p : _ * _ |- _ => destruct p
+         end.
+
 (* break up goal into multiple cases *)
 Ltac break_match :=
   match goal with
@@ -46,9 +53,9 @@ Ltac break_match :=
     match type of x with
     | sumbool _ _ => destruct x
     end
-  | |- context [match ?x with _ => _ end] => case_eq x; intro
+  | |- context [match ?x with _ => _ end] => case_eq x; intros *; intro
   | H : context [match ?x with _ => _ end] |- _ =>
-    let Heq := fresh in case_eq x; intro Heq; rewrite Heq in H
+    let Heq := fresh in case_eq x; intros *; intro Heq; rewrite Heq in *
   end.
 
 (* solves relatively easy goals with some common methods *)


### PR DESCRIPTION
(This is a large PR, but most of it is boilerplate tracking of preconditions -- I list the specific files that need to be reviewed at the end of this description.)

This PR makes significant progress on proving `reassign_pointer_represents`, a pretty fundamental theorem stating that, when I replace an existing table in the concrete state with a new table that has different attributes, the abstract state that represents that concrete state changes in the way I expect.

Along the way, I realized that I had accidentally included a function in `ArchMM.v` that doesn't actually exist in the `arch/mm.c` file. In particular, you cannot convert stage-1 attributes to a mode, because stage-1 tables don't have a bit that says whether the memory is owned. This meant changing some of the code in e.g. `State.v` that talks about Hafnium owning memory -- we can't just look at a bit in the PTE. Instead, since none of the api functions can actually transfer ownership of memory to Hafnium (send/recv buffers are created in memory Hafnium already owns, I believe), I simply determine whether memory is owned by Hafnium by looking at the starting parameters.

I also introduced some "well-formedness" properties about page tables and addresses, creating a new file `PageTablesWf.v`, and added those properties to the `is_valid` condition on `concrete_state`. That means that I can make certain assumptions about the way that page tables are formed; for instance, they have the correct number of entries, and their depth is not more than the maximum depth. And, assuming both the table and address are well-formed, I prove that `page_lookup` always returns a value (which may be an absent PTE -- it just returns some PTE rather than `None`).

The specific files in this PR that could use review are the ones relating to the two changes I detailed above (the rest is largely mechanical pushing `reassign_pointer_represents` into sub-lemmas). This PR is best *not* reviewed commit-by-commit, since there was so much code churn as I figured out my proof strategy.

Please review:
`src/AbstractModel.v`
`src/Concrete/Assumptions/ArchMM.v`
`src/Concrete/PageTablesWf.v`
`src/Concrete/State.v`
This should be a more reasonably-sized diff (190 insertions/53 deletions).