### PR TITLE
Progress on state-change proofs

### DIFF
--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -770,8 +770,6 @@ Section Proofs.
     (* before calling mm_map_root, we have rounded end_ up to the nearest page,
        and we have capped it to not go beyond the end of the table *)
     (N.to_nat end_ <= mm_root_table_count flags * mm_entry_size root_level) ->
-    (* we're not invalidating Hafnium's memory *)
-    (stage_from_flags flags = Stage1 -> stage1_valid attrs = true) ->
     (* we need to know we're actually at the root level *)
     is_root root_level flags ->
     ptable_is_root t flags ->

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -764,8 +764,6 @@ Section Proofs.
     forall attrs begin end_,
       attrs_changed_in_range (ptable_deref conc) idxs (ptable_deref conc ptr) t
                              level attrs begin end_ Stage1 ->
-      (* new attributes say the entry is valid *)
-      stage1_valid attrs = true ->
       represents (abstract_reassign_pointer
                     abst conc ptr attrs begin end_)
                  conc'.
@@ -781,12 +779,12 @@ Section Proofs.
       rewrite accessible_by_abstract_reassign_pointer_stage1 by eauto.
       process_represents;
         cbv [haf_page_valid] in *; basics; cbn [ptable_deref] in *;
-          match goal with
-          | H : root_ptable_wf ?deref _ _
-            |- context [page_lookup ?deref ?t ?s ?a] =>
-            pose proof H; eapply page_lookup_ok in H; eauto; [ ];
-              case_eq (page_lookup deref t s a); basics; try solver; [ ]
-          end;
+          try match goal with
+              | H : root_ptable_wf ?deref _ _
+                |- context [page_lookup ?deref ?t ?s ?a] =>
+                pose proof H; eapply page_lookup_ok in H; eauto; [ ];
+                  case_eq (page_lookup deref t s a); basics; try solver; [ ]
+              end;
           repeat match goal with
                  | _ => progress basics
                  | _ => progress destruct_tuples
@@ -794,7 +792,7 @@ Section Proofs.
                    eapply changed_has_new_attrs in H;
                      cbv [root_ptable_matches_stage]; try solver; [ ]
                  | _ => solver
-                 | _ => cbv [stage1_valid] in *; rewrite is_valid_matches_flag; solver
+                 | _ => cbv [stage1_valid] in *; rewrite is_valid_matches_flag in *; solver
                  | _ => do 2 eexists; split; [solver|]
                  end. }
     { (* stage-2 [owned_by] states match *)
@@ -861,7 +859,6 @@ Section Proofs.
       attrs_changed_in_range (ptable_deref conc) idxs (ptable_deref conc ptr) t
                              level attrs begin end_ stage ->
       level = max_level stage + 1 - length idxs ->
-      (stage = Stage1 -> stage1_valid attrs = true) ->
       represents (abstract_reassign_pointer
                     abst conc ptr attrs begin end_)
                  conc'.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -175,6 +175,15 @@ Section FoldRight.
       cbn [fold_right]; eauto.
   Qed.
 
+  Lemma fold_right_invariant_strong (P : B -> Prop) (f : A -> B -> B) b ls :
+    (forall a b, In a ls -> P b -> P (f a b)) ->
+    P b ->
+    P (fold_right f b ls).
+  Proof.
+    generalize dependent b; induction ls; intros;
+      cbn [fold_right]; eauto.
+  Qed.
+
   Lemma fold_right_ext (f g : A -> B -> B) b ls :
     (forall a b, In a ls -> f a b = g a b) ->
     fold_right f b ls = fold_right g b ls.
@@ -197,6 +206,19 @@ Section FoldLeft.
       cbn [fold_left]; eauto.
   Qed.
 End FoldLeft.
+
+(* Proofs about [filter] *)
+Section Filter.
+  Context {A : Type} (f : A -> bool).
+
+  Lemma filter_none ls :
+    (forall x, In x ls -> f x = false) ->
+    filter f ls = nil.
+  Proof.
+    intro Hfalse.
+    induction ls; cbn [filter]; basics; rewrite ?Hfalse; solver.
+  Qed.
+End Filter.
 
 (* Proofs about [firstn] and [skipn] *)
 Section FirstnSkipn.


### PR DESCRIPTION
This PR proves several of the sublemmas left over by `reassign_pointer_represents`. It also removes an unnecessary precondition from the whole chain of proofs.