### PR TITLE
Prove remaining sublemmas of reassign_pointer_represents modulo lower-level admits

### DIFF
--- a/coq-verification/_CoqProject
+++ b/coq-verification/_CoqProject
@@ -4,6 +4,7 @@ src/Concrete/Datatypes.v
 src/Concrete/Model.v
 src/Concrete/Notations.v
 src/Concrete/PageTablesWf.v
+src/Concrete/Parameters.v
 src/Concrete/PointerLocations.v
 src/Concrete/State.v
 src/Concrete/StateProofs.v

--- a/coq-verification/src/Concrete/Api/Implementation.v
+++ b/coq-verification/src/Concrete/Api/Implementation.v
@@ -16,6 +16,7 @@
 
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.BinNat.
+Require Import Hafnium.Concrete.Parameters.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.

--- a/coq-verification/src/Concrete/Api/Proofs.v
+++ b/coq-verification/src/Concrete/Api/Proofs.v
@@ -16,6 +16,7 @@
 
 Require Import Coq.Arith.PeanoNat.
 Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.Parameters.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Util.Tactics.

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -40,6 +40,8 @@ Axiom va_init : uintvaddr_t -> vaddr_t.
 
 Axiom ipa_add : ipaddr_t -> size_t -> ipaddr_t.
 
+Axiom va_addr : vaddr_t -> uintvaddr_t.
+
 Axiom va_from_pa : paddr_t -> vaddr_t.
 
 Axiom pa_from_va : vaddr_t -> paddr_t.
@@ -52,3 +54,5 @@ Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
 
 (* equality of the paddr_t type is decidable *)
 Axiom paddr_t_eq_dec : forall (a1 a2 : paddr_t), {a1 = a2} + {a1 <> a2}.
+Axiom pa_from_va_id : forall (a : paddr_t), pa_from_va (va_from_pa a) = a.
+Axiom va_init_id : forall (a : vaddr_t), va_init (va_addr a) = a.

--- a/coq-verification/src/Concrete/Assumptions/Addr.v
+++ b/coq-verification/src/Concrete/Assumptions/Addr.v
@@ -55,4 +55,6 @@ Axiom is_aligned : uintpaddr_t -> nat (* PAGE_SIZE *) -> bool.
 (* equality of the paddr_t type is decidable *)
 Axiom paddr_t_eq_dec : forall (a1 a2 : paddr_t), {a1 = a2} + {a1 <> a2}.
 Axiom pa_from_va_id : forall (a : paddr_t), pa_from_va (va_from_pa a) = a.
+Axiom va_from_pa_id : forall (a : vaddr_t), va_from_pa (pa_from_va a) = a.
 Axiom va_init_id : forall (a : vaddr_t), va_init (va_addr a) = a.
+Axiom va_addr_id : forall (a : uintvaddr_t), va_addr (va_init a) = a.

--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -77,8 +77,13 @@ Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 P
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
+
 (* arch_mm_pte_is_valid is true iff [ attrs & PTE_VALID != 0 ] *)
 Axiom is_valid_matches_flag :
   forall pte level,
     let attrs := arch_mm_pte_attrs pte level in
     arch_mm_pte_is_valid pte level = negb (N.eqb (N.land attrs PTE_VALID) 0).
+
+(* The attributes of absent PTEs are always the same *)
+Axiom absent_attrs : attributes.
+Axiom absent_pte_attrs : forall level, arch_mm_pte_attrs (arch_mm_absent_pte level) level = absent_attrs.

--- a/coq-verification/src/Concrete/Assumptions/PageTables.v
+++ b/coq-verification/src/Concrete/Assumptions/PageTables.v
@@ -140,3 +140,23 @@ Definition page_lookup
   | Some table_ptr =>
     page_lookup' ptable_deref a (ptable_deref table_ptr) (max_level s + 1) s
   end.
+
+(* This dummy value is left as an axiom so we can't rely on its properties *)
+Axiom dummy_attributes : attributes.
+
+Definition page_attrs'
+           (ptable_deref : ptable_pointer -> mm_page_table)
+           (a : uintpaddr_t) (table : mm_page_table)
+           (level_above : nat) (s : Stage) : attributes :=
+  match page_lookup' ptable_deref a table level_above s with
+  | Some (pte, level) => arch_mm_pte_attrs pte level
+  | None => dummy_attributes
+  end.
+Definition page_attrs
+           (ptable_deref : ptable_pointer -> mm_page_table)
+           (root_ptable : mm_ptable) (s : Stage)
+           (a : uintpaddr_t) : attributes :=
+  match page_lookup ptable_deref root_ptable s a with
+  | Some (pte, level) => arch_mm_pte_attrs pte level
+  | None => dummy_attributes
+  end.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -495,8 +495,8 @@ Fixpoint mm_map_level
                        */ *)
            if ((if unmap
                 then !arch_mm_pte_is_present pte level
-                else arch_mm_pte_is_block pte level)
-                 && (arch_mm_pte_attrs pte level =? attrs)%N)%bool
+                else (arch_mm_pte_is_block pte level)
+                       && (arch_mm_pte_attrs pte level =? attrs))%N)%bool
            then
              (* done; continue to the next entry *)
              (* begin = mm_start_of_next_block(begin, entry_size);

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -582,41 +582,41 @@ Fixpoint mm_map_level
                      (s, begin, pa, table, pte_index, failed, ppool, break)
                    | (true, nt, s, ppool) =>
 
-                 (* /*
-                  * If the subtable is now empty, replace it with an
-                  * absent entry at this level. We never need to do
-                  * break-before-makes here because we are assigning
-                  * an absent value.
-                  */
-                     if (commit && unmap &&
-                         mm_page_table_is_empty(nt, level - 1)) {
-                             pte_t v = *pte;
-                             *pte = arch_mm_absent_pte(level);
-                             mm_free_page_pte(v, level, ppool);
-                     } *)
-                 let '(pte, s, ppool) :=
-                     if (commit && unmap &&
-                                mm_page_table_is_empty nt (level - 1))%bool
-                     then
-                       let v := pte in
-                       (* N.B. in functional programming we can't edit data under
-                          a pointer, so we need to construct a new table and pass
-                          it along. *)
-                       let table :=
-                           table.(mm_page_table_replace_entry)
-                                   (arch_mm_absent_pte level) pte_index in
-                       let '(s, ppool) := mm_free_page_pte s v level ppool in
-                       (pte, s, ppool)
-                     else (pte, s, ppool) in
-                 (* done; continue to the next entry *)
-                 (* begin = mm_start_of_next_block(begin, entry_size);
-                    pa = mm_pa_start_of_next_block(pa, entry_size);
-                    pte++; *)
-                 let begin := mm_start_of_next_block begin entry_size in
-                 let pa := mm_pa_start_of_next_block pa entry_size in
-                 let pte_index := S pte_index in
-                 (s, begin, pa, table, pte_index, failed, ppool, continue)
-               end end end) in
+                    (* /*
+                     * If the subtable is now empty, replace it with an
+                     * absent entry at this level. We never need to do
+                     * break-before-makes here because we are assigning
+                     * an absent value.
+                     */
+                        if (commit && unmap &&
+                            mm_page_table_is_empty(nt, level - 1)) {
+                                pte_t v = *pte;
+                                *pte = arch_mm_absent_pte(level);
+                                mm_free_page_pte(v, level, ppool);
+                        } *)
+                     let '(pte, s, ppool) :=
+                         if (commit && unmap &&
+                                    mm_page_table_is_empty nt (level - 1))%bool
+                         then
+                           let v := pte in
+                          (* N.B. in functional programming we can't edit data under
+                             a pointer, so we need to construct a new table and pass
+                             it along. *)
+                          let table :=
+                              table.(mm_page_table_replace_entry)
+                                      (arch_mm_absent_pte level) pte_index in
+                          let '(s, ppool) := mm_free_page_pte s v level ppool in
+                          (pte, s, ppool)
+                        else (pte, s, ppool) in
+                    (* done; continue to the next entry *)
+                    (* begin = mm_start_of_next_block(begin, entry_size);
+                       pa = mm_pa_start_of_next_block(pa, entry_size);
+                       pte++; *)
+                    let begin := mm_start_of_next_block begin entry_size in
+                    let pa := mm_pa_start_of_next_block pa entry_size in
+                    let pte_index := S pte_index in
+                    (s, begin, pa, table, pte_index, failed, ppool, continue)
+                  end end end) in
 
   (* return true; *)
   (* N.B. have to check here if the loop returned false partway through *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -18,6 +18,7 @@ Require Import Coq.NArith.BinNat.
 Require Import Coq.Lists.List.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Concrete.Notations.
+Require Import Hafnium.Concrete.Parameters.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Util.Loops.
 Require Import Hafnium.Concrete.Assumptions.Addr.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -464,7 +464,7 @@ Section Proofs.
   Proof.
     intro H. cbv [is_root] in H; rewrite H; intros.
     cbv [address_matches_indices]; autorewrite with push_length; intro i.
-    destruct i; [basics|solver].
+    destruct i; basics; [|solver].
     autorewrite with push_nth_default.
     rewrite index_of_uintvaddr by solver.
     rewrite Nat.sub_0_r, mm_max_level_eq.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -531,19 +531,19 @@ Section Proofs.
      translation it returns a new table to the caller and the caller updates the
      state) *)
   Lemma mm_map_level_represents
-        (conc : concrete_state)
-        begin end_ pa attrs table level flags ppool :
-    (snd (fst (mm_map_level
-                 conc begin end_ pa attrs table level flags ppool))) = conc.
+        (conc : concrete_state) level :
+    forall begin end_ pa attrs table flags ppool,
+             (snd (fst (mm_map_level
+                          conc begin end_ pa attrs table level flags ppool))) = conc.
   Proof.
-    autounfold; cbv [mm_map_level].
-    repeat match goal with
-           | _ => simplify_step
-           | _ => apply while_loop_invariant; [ | solver ]
-           | _ => rewrite mm_free_page_pte_represents
-           | _ => rewrite mm_replace_entry_represents
-           | _ => rewrite mm_populate_table_pte_represents
-           end.
+    induction level; autounfold; cbn [mm_map_level];
+      repeat match goal with
+             | _ => simplify_step
+             | _ => apply while_loop_invariant; [ | solver ]
+             | _ => rewrite mm_free_page_pte_represents
+             | _ => rewrite mm_replace_entry_represents
+             | _ => rewrite mm_populate_table_pte_represents
+             end.
   Qed.
 
   Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level

--- a/coq-verification/src/Concrete/Model.v
+++ b/coq-verification/src/Concrete/Model.v
@@ -17,6 +17,7 @@
 Require Import Coq.Lists.List.
 Require Import Coq.Arith.PeanoNat.
 Require Import Hafnium.AbstractModel.
+Require Import Hafnium.Concrete.Parameters.
 Require Import Hafnium.Concrete.State.
 Require Import Hafnium.Concrete.Datatypes.
 Require Import Hafnium.Util.Tactics.

--- a/coq-verification/src/Concrete/Parameters.v
+++ b/coq-verification/src/Concrete/Parameters.v
@@ -1,0 +1,68 @@
+
+(*
+ * Copyright 2019 Jade Philipoom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *)
+
+Require Import Coq.Lists.List.
+Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Assumptions.Addr.
+Require Import Hafnium.Concrete.Assumptions.ArchMM.
+Require Import Hafnium.Concrete.Assumptions.Constants.
+Require Import Hafnium.Concrete.Assumptions.Datatypes.
+Require Import Hafnium.Concrete.MM.Datatypes.
+
+(*** This file defines the starting parameters for the concrete state. It is kept
+   separate so that definitions using concrete_params can be used in State.v ***)
+
+Record vm :=
+  {
+    vm_ptable : mm_ptable;
+    vm_id : nat;
+  }.
+
+(* N.B. there can be multiple page tables at the root level *)
+Definition vm_root_tables (v : vm) : list ptable_pointer :=
+  ptr_from_va (va_from_pa v.(vm_ptable).(root)).
+
+(* starting parameters -- don't change *)
+Class concrete_params :=
+  {
+    vms : list vm;
+    hafnium_ptable : mm_ptable;
+  }.
+
+(* N.B. there can be multiple page tables at the root level *)
+Definition hafnium_root_tables {cp : concrete_params} : list ptable_pointer :=
+  ptr_from_va (va_from_pa hafnium_ptable.(root)).
+
+Definition all_root_ptables {cp : concrete_params} : list mm_ptable :=
+  hafnium_ptable :: map vm_ptable vms.
+
+Definition all_root_ptable_pointers {cp : concrete_params}
+  : list ptable_pointer := hafnium_root_tables ++ flat_map vm_root_tables vms.
+
+Class params_valid {cp : concrete_params} :=
+  {
+    correct_number_of_root_tables_stage1 :
+      length (ptr_from_va (va_from_pa (hafnium_ptable.(root))))
+      = arch_mm_stage1_root_table_count;
+    correct_number_of_root_tables_stage2 :
+      forall t,
+        In t (map vm_ptable vms) ->
+        length (ptr_from_va (va_from_pa t.(root)))
+        = arch_mm_stage2_root_table_count;
+    no_duplicate_ptables : NoDup all_root_ptables;
+    no_duplicate_ids : NoDup (map vm_id vms)
+  }.

--- a/coq-verification/src/Concrete/PointerLocations.v
+++ b/coq-verification/src/Concrete/PointerLocations.v
@@ -18,6 +18,7 @@ Require Import Coq.Lists.List.
 Require Import Coq.Arith.PeanoNat.
 Require Import Coq.NArith.BinNat.
 Require Import Hafnium.Concrete.Datatypes.
+Require Import Hafnium.Concrete.Parameters.
 Require Import Hafnium.Concrete.Assumptions.Addr.
 Require Import Hafnium.Concrete.Assumptions.ArchMM.
 Require Import Hafnium.Concrete.Assumptions.Constants.
@@ -28,8 +29,44 @@ Require Import Hafnium.Concrete.MM.Datatypes.
 Require Import Hafnium.Util.List.
 Require Import Hafnium.Util.Tactics.
 
+(* TODO : find a different place for this section? *)
+Section AddressMatchesIndices.
+  Definition address_matches_indices_alt stage a idxs : Prop :=
+    firstn (length idxs)
+           (rev
+              (map (fun lvl => get_index stage lvl a)
+                   (seq 0 (S (S (max_level stage)))))) = idxs.
+  Definition address_matches_indices stage a idxs : Prop :=
+    (forall i,
+        i < length idxs ->
+        get_index stage (max_level stage + 1 - i) a = nth_default 0 idxs i).
+
+  Lemma address_matches_indices_iff stage a idxs :
+    address_matches_indices_alt stage a idxs <-> address_matches_indices stage a idxs.
+  Admitted.
+
+  Definition address_matches_indices_alt_dec stage a idxs :
+    {address_matches_indices_alt stage a idxs} + {~ address_matches_indices_alt stage a idxs}.
+  Proof.
+    cbv [address_matches_indices_alt].
+    apply list_eq_dec, Nat.eq_dec.
+  Defined.
+
+  Definition address_matches_indices_dec stage a idxs :
+    {address_matches_indices stage a idxs} + {~ address_matches_indices stage a idxs}.
+  Proof.
+    destruct (address_matches_indices_alt_dec stage a idxs);
+      rewrite address_matches_indices_iff in *; solver.
+  Defined.
+End AddressMatchesIndices.
+
+Section LevelFromIndices.
+  Definition level_from_indices stage (idxs : list nat) : nat :=
+    max_level stage + 2 - length idxs.
+End LevelFromIndices.
+
 Section PointerLocations.
-  Context (ptable_deref : ptable_pointer -> mm_page_table).
+  Context (deref : ptable_pointer -> mm_page_table).
 
   (* We haven't formalized anywhere that pointers don't repeat, so we return a
      list of all locations where the provided pointer exists even though we
@@ -45,7 +82,7 @@ Section PointerLocations.
       if ptable_pointer_eq_dec root ptr
       then cons nil nil
       else
-        let ptable := ptable_deref root in
+        let ptable := deref root in
         flat_map
           (fun index =>
              match get_entry ptable index with
@@ -102,13 +139,16 @@ Section PointerLocations.
   (* This section includes some definitions which use information from the
      concrete parameters *)
   Section with_concrete_params.
-    Context (vm_ptables : list mm_ptable) (haf_ptable : mm_ptable) (ppool : mpool).
+    Context {cp : concrete_params}.
 
-    Inductive has_location : ptable_pointer -> pointer_location ppool -> Prop :=
+    Let vm_ptables := map vm_ptable vms.
+
+    Inductive has_location {ppool : mpool}
+      : ptable_pointer -> pointer_location ppool -> Prop :=
     | has_table_loc_stage1 :
         forall idxs ptr,
-          In idxs (index_sequences_to_pointer ptr haf_ptable Stage1) ->
-          has_location ptr (table_loc ppool haf_ptable idxs)
+          In idxs (index_sequences_to_pointer ptr hafnium_ptable Stage1) ->
+          has_location ptr (table_loc ppool hafnium_ptable idxs)
     | has_table_loc_stage2 :
         forall root_ptable idxs ptr,
           In root_ptable vm_ptables ->
@@ -120,181 +160,277 @@ Section PointerLocations.
           has_location ptr (mpool_loc ppool)
     .
 
-    (* TODO: just guessing that this might come in handy; remove if unused *)
-    Lemma table_locations_exclusive ptr1 ptr2 root_ptable idxs :
-      has_location ptr1 (table_loc ppool root_ptable idxs) ->
-      has_location ptr2 (table_loc ppool root_ptable idxs) ->
-      ptr1 = ptr2.
-    Admitted.
-
     (* every ptable_pointer has at most one location *)
-    Definition locations_exclusive : Prop :=
+    Definition locations_exclusive (ppool : mpool) : Prop :=
       forall ptr loc1 loc2,
-        has_location ptr loc1 -> has_location ptr loc2 -> loc1 = loc2.
+        @has_location ppool ptr loc1 -> @has_location ppool ptr loc2 -> loc1 = loc2.
   End with_concrete_params.
 
-  Lemma index_sequences_to_pointer''_root ptr level :
-    0 < level ->
-    In nil (index_sequences_to_pointer'' ptr ptr level).
-  Proof.
-    destruct level; [solver|]; intros.
-    cbn [index_sequences_to_pointer''].
-    break_match; solver.
-  Qed.
 
-  Lemma index_sequences_to_pointer'_nth_default root_list stage :
-    forall i j k,
-      i < length root_list ->
-      k = i + j ->
-      In (k :: nil)
-         (index_sequences_to_pointer'
-            (nth_default_oobe root_list i) j root_list stage).
-  Proof.
-    cbv [nth_default_oobe]. pose proof (max_level_pos stage).
-    induction root_list; destruct i; cbn [length index_sequences_to_pointer'];
-      repeat match goal with
-             | _ => progress basics
-             | _ => progress autorewrite with push_nth_default
-             | _ => rewrite Nat.add_0_l
-             | _ => apply in_or_app
-             | _ => left; apply in_map, index_sequences_to_pointer''_root; solver
-             | _ => right; apply IHroot_list; solver
-             | _ => solver
-             end.
-  Qed.
+  Section Proofs.
+    Lemma index_sequences_to_pointer''_root ptr level :
+      0 < level ->
+      In nil (index_sequences_to_pointer'' ptr ptr level).
+    Proof.
+      destruct level; [solver|]; intros.
+      cbn [index_sequences_to_pointer''].
+      break_match; solver.
+    Qed.
 
-  (* Helper lemma for [nth_error_index_sequences_root] *)
-  Lemma nth_error_index_sequences_root' root_ptrs stage ptr :
-    forall i root_index,
-      nth_error root_ptrs i = Some ptr ->
-      In (cons (root_index + i) nil)
-         (index_sequences_to_pointer' ptr root_index root_ptrs stage).
-  Proof.
-    induction root_ptrs; [ intros *; rewrite nth_error_nil; solver | ].
-    destruct i; cbn [nth_error index_sequences_to_pointer']; basics.
-    { apply in_or_app; left. rewrite Nat.add_0_r. apply in_map.
-      apply index_sequences_to_pointer''_root; solver. }
-    { apply in_or_app; right. rewrite <-Nat.add_succ_comm.
-      solver. }
-  Qed.
+    Lemma index_sequences_to_pointer'_nth_default root_list stage :
+      forall i j k,
+        i < length root_list ->
+        k = i + j ->
+        In (k :: nil)
+           (index_sequences_to_pointer'
+              (nth_default_oobe root_list i) j root_list stage).
+    Proof.
+      cbv [nth_default_oobe]. pose proof (max_level_pos stage).
+      induction root_list; destruct i; cbn [length index_sequences_to_pointer'];
+        repeat match goal with
+               | _ => progress basics
+               | _ => progress autorewrite with push_nth_default
+               | _ => rewrite Nat.add_0_l
+               | _ => apply in_or_app
+               | _ => left; apply in_map, index_sequences_to_pointer''_root; solver
+               | _ => right; apply IHroot_list; solver
+               | _ => solver
+               end.
+    Qed.
 
-  (* If you're searching for the index sequences leading to [ptr], and [ptr] is
+    (* Helper lemma for [nth_error_index_sequences_root] *)
+    Lemma nth_error_index_sequences_root' root_ptrs stage ptr :
+      forall i root_index,
+        nth_error root_ptrs i = Some ptr ->
+        In (cons (root_index + i) nil)
+           (index_sequences_to_pointer' ptr root_index root_ptrs stage).
+    Proof.
+      induction root_ptrs; [ intros *; rewrite nth_error_nil; solver | ].
+      destruct i; cbn [nth_error index_sequences_to_pointer']; basics.
+      { apply in_or_app; left. rewrite Nat.add_0_r. apply in_map.
+        apply index_sequences_to_pointer''_root; solver. }
+      { apply in_or_app; right. rewrite <-Nat.add_succ_comm.
+        solver. }
+    Qed.
+
+    (* If you're searching for the index sequences leading to [ptr], and [ptr] is
      a pointer to the root page table at index [i] in the root table list, then
      the resulting index sequences will include (cons i nil).*)
-  Lemma nth_error_index_sequences_root root_ptable i stage ptr :
-    nth_error (ptr_from_va (va_from_pa (root root_ptable))) i = Some ptr ->
-    In (cons i nil) (index_sequences_to_pointer ptr root_ptable stage).
-  Proof.
-    cbv [index_sequences_to_pointer]; intro Hnth.
-    eapply nth_error_index_sequences_root' with (root_index:=0) in Hnth.
-    rewrite Nat.add_0_l in Hnth. solver.
-  Qed.
+    Lemma nth_error_index_sequences_root root_ptable i stage ptr :
+      nth_error (ptr_from_va (va_from_pa (root root_ptable))) i = Some ptr ->
+      In (cons i nil) (index_sequences_to_pointer ptr root_ptable stage).
+    Proof.
+      cbv [index_sequences_to_pointer]; intro Hnth.
+      eapply nth_error_index_sequences_root' with (root_index:=0) in Hnth.
+      rewrite Nat.add_0_l in Hnth. solver.
+    Qed.
 
-  Lemma index_sequences_not_nil' ptr root_ptrs stage :
-    Exists (fun root_ptr =>
-              index_sequences_to_pointer''
-                ptr root_ptr (max_level stage + 1) <> nil)
-        root_ptrs ->
-    forall root_index,
-      index_sequences_to_pointer' ptr root_index root_ptrs stage <> nil.
-  Proof.
-    induction 1; cbn [index_sequences_to_pointer'];
-      eauto using app_not_nil_l, app_not_nil_r, map_not_nil.
-  Qed.
+    Lemma index_sequences_not_nil' ptr root_ptrs stage :
+      Exists (fun root_ptr =>
+                index_sequences_to_pointer''
+                  ptr root_ptr (max_level stage + 1) <> nil)
+             root_ptrs ->
+      forall root_index,
+        index_sequences_to_pointer' ptr root_index root_ptrs stage <> nil.
+    Proof.
+      induction 1; cbn [index_sequences_to_pointer'];
+        eauto using app_not_nil_l, app_not_nil_r, map_not_nil.
+    Qed.
 
-  Lemma index_sequences_not_nil ptr root_ptable stage :
-    Exists (fun root_ptr =>
-              index_sequences_to_pointer''
-                ptr root_ptr (max_level stage + 1) <> nil)
-        (ptr_from_va (va_from_pa (root root_ptable))) ->
-    index_sequences_to_pointer ptr root_ptable stage <> nil.
-  Proof.
-    cbv [index_sequences_to_pointer]. basics.
-    apply index_sequences_not_nil'; eauto.
-  Qed.
+    Lemma index_sequences_not_nil ptr root_ptable stage :
+      Exists (fun root_ptr =>
+                index_sequences_to_pointer''
+                  ptr root_ptr (max_level stage + 1) <> nil)
+             (ptr_from_va (va_from_pa (root root_ptable))) ->
+      index_sequences_to_pointer ptr root_ptable stage <> nil.
+    Proof.
+      cbv [index_sequences_to_pointer]. basics.
+      apply index_sequences_not_nil'; eauto.
+    Qed.
 
-  Lemma get_entry_index_sequences level :
-    forall i root_ptr e,
-      0 < level ->
-      get_entry (ptable_deref root_ptr) i = Some e ->
-      arch_mm_pte_is_table e level = true ->
-      index_sequences_to_pointer''
-        (ptable_pointer_from_address (arch_mm_table_from_pte e level))
-        root_ptr (S level) <> nil.
-  Proof.
-    basics; cbn [index_sequences_to_pointer''];
-      match goal with
-      | H : get_entry _ _ = Some _ |- _ =>
-        pose proof H; cbv [get_entry] in H; apply nth_error_Some_range in H
-      end;
-      repeat match goal with
-             | _ => progress basics
-             | H : get_entry _ _ = Some _ |- _ => rewrite H
-             | _ => break_match
-             | _ => apply flat_map_not_nil with (a:=i)
-             | _ => apply in_seq; solver
-             | _ => solver
-             | _ => solve [eauto using map_not_nil, In_not_nil,
-                           index_sequences_to_pointer''_root]
-             end.
-  Qed.
+    Lemma get_entry_index_sequences level :
+      forall i root_ptr e,
+        0 < level ->
+        get_entry (deref root_ptr) i = Some e ->
+        arch_mm_pte_is_table e level = true ->
+        index_sequences_to_pointer''
+          (ptable_pointer_from_address (arch_mm_table_from_pte e level))
+          root_ptr (S level) <> nil.
+    Proof.
+      basics; cbn [index_sequences_to_pointer''];
+        match goal with
+        | H : get_entry _ _ = Some _ |- _ =>
+          pose proof H; cbv [get_entry] in H; apply nth_error_Some_range in H
+        end;
+        repeat match goal with
+               | _ => progress basics
+               | H : get_entry _ _ = Some _ |- _ => rewrite H
+               | _ => break_match
+               | _ => apply flat_map_not_nil with (a:=i)
+               | _ => apply in_seq; solver
+               | _ => solver
+               | _ => solve [eauto using map_not_nil, In_not_nil,
+                             index_sequences_to_pointer''_root]
+               end.
+    Qed.
 
-  Lemma page_lookup'_proper deref2 level stage :
-    forall root_ptr,
+    Lemma page_lookup'_proper deref2 level stage :
+      forall root_ptr,
+        (forall ptr,
+            index_sequences_to_pointer'' ptr root_ptr level <> nil ->
+            deref ptr = deref2 ptr) ->
+        forall a,
+          page_lookup' deref a (deref root_ptr) level stage
+          = page_lookup' deref2 a (deref root_ptr) level stage.
+    Proof.
+      induction level; cbn [page_lookup'];
+        [ | destruct (Nat.eq_dec level 0); [ basics; reflexivity | ] ];
+        repeat match goal with
+               | _ => progress basics
+               | _ => break_match
+               | H : _ |- _ =>
+                 rewrite <-H; [ | eapply get_entry_index_sequences; solver ]
+               | H : context [deref _ = deref2 _] |- _ => apply H
+               | _ => apply IHlevel
+               | _ => solver
+               end.
+      cbn [index_sequences_to_pointer''].
+      break_match; [ solver | ].
+      cbv [get_entry] in *.
+      match goal with H : _ |- _ =>
+                      pose proof H;
+                        apply nth_error_Some_range in H
+      end.
+      match goal with H : context [get_index ?s ?l ?addr] |- _ =>
+                      eapply flat_map_not_nil with (a0:=get_index s l addr);
+                        [ apply in_seq; solver | ]
+      end.
+      repeat break_match; try solver; [ ].
+      apply map_not_nil; solver.
+    Qed.
+
+    Lemma page_lookup_proper deref2 root_ptable stage :
       (forall ptr,
-          index_sequences_to_pointer'' ptr root_ptr level <> nil ->
-          ptable_deref ptr = deref2 ptr) ->
+          index_sequences_to_pointer ptr root_ptable stage <> nil ->
+          deref ptr = deref2 ptr) ->
       forall a,
-        page_lookup' ptable_deref a (ptable_deref root_ptr) level stage
-        = page_lookup' deref2 a (ptable_deref root_ptr) level stage.
-  Proof.
-    induction level; cbn [page_lookup'];
-      [ | destruct (Nat.eq_dec level 0); [ basics; reflexivity | ] ];
-      repeat match goal with
-             | _ => progress basics
-             | _ => break_match
-             | H : _ |- _ =>
-               rewrite <-H; [ | eapply get_entry_index_sequences; solver ]
-             | H : context [ptable_deref _ = deref2 _] |- _ => apply H
-             | _ => apply IHlevel
-             | _ => solver
-             end.
-    cbn [index_sequences_to_pointer''].
-    break_match; [ solver | ].
-    cbv [get_entry] in *.
-    match goal with H : _ |- _ =>
-                    pose proof H;
-                      apply nth_error_Some_range in H
-    end.
-    match goal with H : context [get_index ?s ?l ?addr] |- _ =>
-                    eapply flat_map_not_nil with (a0:=get_index s l addr);
-                      [ apply in_seq; solver | ]
-    end.
-    repeat break_match; try solver; [ ].
-    apply map_not_nil; solver.
-  Qed.
+        page_lookup deref root_ptable stage a = page_lookup deref2 root_ptable stage a.
+    Proof.
+      cbv [page_lookup];
+        repeat match goal with
+               | _ => progress basics
+               | H : _ = Some _ |- _ =>
+                 pose proof (nth_error_In _ _ H);
+                   eapply nth_error_index_sequences_root in H;
+                   [ | solver .. ]
+               | H : context [deref _ = deref2 _] |- _ => rewrite <-H by solver
+               | H : context [deref _ = deref2 _] |- _ =>
+                 apply H; apply index_sequences_not_nil
+               | _ => apply page_lookup'_proper
+               | _ => rewrite Exists_exists
+               | _ => break_match
+               | _ => solver
+               end.
+    Qed.
 
-  Lemma page_lookup_proper deref2 root_ptable stage :
-    (forall ptr,
-        index_sequences_to_pointer ptr root_ptable stage <> nil ->
-        ptable_deref ptr = deref2 ptr) ->
-    forall a,
-      page_lookup ptable_deref root_ptable stage a = page_lookup deref2 root_ptable stage a.
-  Proof.
-    cbv [page_lookup];
-      repeat match goal with
-             | _ => progress basics
-             | H : _ = Some _ |- _ =>
-               pose proof (nth_error_In _ _ H);
-                 eapply nth_error_index_sequences_root in H;
-                 [ | solver .. ]
-             | H : context [ptable_deref _ = deref2 _] |- _ => rewrite <-H by solver
-             | H : context [ptable_deref _ = deref2 _] |- _ =>
-               apply H; apply index_sequences_not_nil
-             | _ => apply page_lookup'_proper
-             | _ => rewrite Exists_exists
-             | _ => break_match
-             | _ => solver
-             end.
-  Qed.
+    (* TODO: clean up WIP proofs, move definition of page_table_lookup elsewhere *)
+    (*** The below proofs are a work in progress to connect index_sequences_to_pointer with page_lookup ***)
+
+    Section PageTableLookup.
+      (* TODO: remove if unused *)
+      (* Look up the page table that corresponds to the given indices *)
+      Fixpoint page_table_lookup' root_ptr (idxs : list nat) level : option ptable_pointer :=
+        match idxs with
+        | nil => Some root_ptr
+        | cons i idxs' =>
+          let table := deref root_ptr in
+          match get_entry table i with
+          | Some pte =>
+            if arch_mm_pte_is_table pte level
+            then
+              let next_ptr := ptable_pointer_from_address (arch_mm_table_from_pte pte level) in
+              page_table_lookup' next_ptr idxs' (level - 1)
+            else Some root_ptr
+          | None => None
+          end
+        end.
+      Definition page_table_lookup root_ptable idxs stage : option ptable_pointer :=
+        let root_tables := ptr_from_va (va_from_pa (root root_ptable)) in
+        match idxs with
+        | nil => None
+        | cons i idxs' =>
+          match nth_error root_tables i with
+          | Some table_ptr => page_table_lookup' table_ptr idxs' (max_level stage)
+          | None => None
+          end
+        end.
+    End PageTableLookup.
+
+    (* TODO: remove if unused *)
+    Lemma page_table_lookup_equiv root_ptable idxs stage a ptr :
+      address_matches_indices stage a idxs ->
+      page_table_lookup root_ptable idxs stage = Some ptr ->
+      page_lookup deref root_ptable stage a
+      = page_lookup' deref a (deref ptr) (level_from_indices stage idxs) stage.
+    Admitted.
+
+    Section with_concrete_params.
+      Context {cp : concrete_params}.
+
+      Definition root_ptable_matches_stage root_ptable stage : Prop :=
+        match stage with
+        | Stage1 => root_ptable = hafnium_ptable
+        | Stage2 => In root_ptable (map vm_ptable vms)
+        end.
+
+      Lemma has_location_index_sequence ppool ptr root_ptable idxs stage :
+        root_ptable_matches_stage root_ptable stage ->
+        ~ In hafnium_ptable (map vm_ptable vms) ->
+        has_location ptr (table_loc ppool root_ptable idxs) ->
+        In idxs (index_sequences_to_pointer ptr root_ptable stage).
+      Proof.
+        intros.
+        match goal with H : context [has_location] |- _ =>
+                        invert H end; destruct stage; try solver.
+      Qed.
+
+      (* TODO: remove if unused *)
+      Lemma has_location_step
+            ppool root_ptable stage idxs ptr i level e :
+        root_ptable_matches_stage root_ptable stage ->
+        has_location ptr (table_loc ppool root_ptable idxs) ->
+        level = level_from_indices stage idxs ->
+        get_entry (deref ptr) i = Some e ->
+        arch_mm_pte_is_table e level = true ->
+        let next_ptr :=
+            ptable_pointer_from_address (arch_mm_table_from_pte e level) in
+        has_location next_ptr (table_loc ppool root_ptable (idxs ++ cons i nil)).
+      Admitted.
+
+      (* TODO: remove if unused *)
+      Lemma has_location_table_lookup ppool ptr root_ptable idxs stage :
+        has_location ptr (table_loc ppool root_ptable idxs) ->
+        page_table_lookup root_ptable idxs stage = Some ptr.
+      Admitted.
+
+      (* TODO: remove if unused *)
+      Lemma page_lookup_from_location root_ptable idxs ppool stage a ptr :
+        has_location ptr (table_loc ppool root_ptable idxs) ->
+        address_matches_indices stage a idxs ->
+        page_lookup deref root_ptable stage a
+        = page_lookup' deref a (deref ptr) (level_from_indices stage idxs) stage.
+      Proof.
+        intros;
+          match goal with H : _ |- _ =>  eapply has_location_table_lookup in H end.
+        eapply page_table_lookup_equiv; eauto.
+      Qed.
+
+      (* TODO: just guessing that this might come in handy; remove if unused *)
+      Lemma table_locations_exclusive ppool ptr1 ptr2 root_ptable idxs :
+        has_location ptr1 (table_loc ppool root_ptable idxs) ->
+        has_location ptr2 (table_loc ppool root_ptable idxs) ->
+        ptr1 = ptr2.
+      Admitted.
+    End with_concrete_params.
+  End Proofs.
 End PointerLocations.

--- a/coq-verification/src/Concrete/PointerLocations.v
+++ b/coq-verification/src/Concrete/PointerLocations.v
@@ -58,6 +58,14 @@ Section AddressMatchesIndices.
     destruct (address_matches_indices_alt_dec stage a idxs);
       rewrite address_matches_indices_iff in *; solver.
   Defined.
+
+  Definition address_matches_indices_decidable stage a idxs :
+    Decidable.decidable (address_matches_indices stage a idxs).
+  Proof.
+    cbv [Decidable.decidable].
+    destruct (address_matches_indices_alt_dec stage a idxs);
+      rewrite address_matches_indices_iff in *; solver.
+  Defined.
 End AddressMatchesIndices.
 
 Section LevelFromIndices.

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -80,9 +80,8 @@ Definition vm_page_valid {cp : concrete_params}
 
 Definition haf_page_valid
            {cp : concrete_params} (s : concrete_state) (a : paddr_t) : Prop :=
-  exists (e : pte_t) (lvl : nat),
-    page_lookup s.(ptable_deref) hafnium_ptable Stage1 a.(pa_addr) = Some (e, lvl)
-    /\ arch_mm_pte_is_valid e lvl = true.
+  let attrs := page_attrs s.(ptable_deref) hafnium_ptable Stage1 a.(pa_addr) in
+  (N.land attrs PTE_VALID <> 0)%N.
 
 Definition vm_page_owned {cp : concrete_params}
            (s : concrete_state) (v : vm) (a : paddr_t) : Prop :=

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -56,7 +56,10 @@ Section Proofs.
     abstract_state_equiv abst abst' ->
     represents abst conc ->
     represents abst' conc.
-  Admitted.
+  Proof.
+    intro Hequiv. destruct Hequiv as [Hown Haccess].
+    cbv [represents]; basics; rewrite <-?Hown, <-?Haccess; solver.
+  Qed.
 
   (* [represents] includes [is_valid] as one of its conditions *)
   Lemma represents_valid_concrete conc : (exists abst, represents abst conc) -> is_valid conc.

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -155,6 +155,70 @@ Section Proofs.
     intro; solver.
   Qed.
 
+  Lemma vm_find_Some v : In v vms -> vm_find (vm_id v) = Some v.
+  Proof.
+    cbv [vm_find].
+    repeat match goal with
+           | _ => progress basics
+           | _ => inversion_bool
+           | _ => destruct_vm_eq
+           | H : _ |- _ => apply find_some in H
+           | H : context [find ?f] |- _ => eapply (find_none f) in H; [|solver]
+           | |- context [find ?f ?l] => case_eq (find f l)
+           | H : ?v1 <> ?v2 |- _ =>
+             assert (vm_id v1 <> vm_id v2)
+               by eauto using NoDup_map_neq, no_duplicate_ids; solver
+           | _ => solver
+           end.
+  Qed.
+  Hint Resolve vm_find_Some.
+
+  Lemma vm_find_sound v vid : vm_find vid = Some v -> vm_id v = vid.
+  Proof.
+    cbv [vm_find].
+    repeat match goal with
+           | _ => progress basics
+           | _ => inversion_bool
+           | H : _ |- _ => apply find_some in H
+           | _ => solver
+           end.
+  Qed.
+  Hint Resolve vm_find_sound.
+
+  Lemma vm_find_unique_entity v1 v2 vid :
+    vm_find vid = Some v2 ->
+    In v1 vms ->
+    v1 <> v2 ->
+    ~ (@eq entity_id (inl vid) (inl (vm_id v1))).
+  Proof.
+    cbv [vm_find].
+    repeat match goal with
+           | _ => progress basics
+           | _ => inversion_bool
+           | H : _ |- _ => apply find_some in H
+           | |- inl _ <> inl _ =>
+             let H := fresh in intro H; invert H
+           | H : ?v1 <> ?v2 |- _ =>
+             assert (vm_id v1 <> vm_id v2)
+               by eauto using NoDup_map_neq, no_duplicate_ids; solver
+           | _ => solver
+           end.
+  Qed.
+  Hint Resolve vm_find_unique_entity.
+
+  Lemma vm_find_In vid v : vm_find vid = Some v -> In v vms.
+  Proof.
+    cbv [vm_find].
+    repeat match goal with
+           | _ => progress basics
+           | _ => inversion_bool
+           | H : _ |- _ => apply find_some in H
+           | _ => solver
+           end.
+  Qed.
+  Hint Resolve vm_find_In.
+
+
   Lemma index_sequences_update_deref'' deref ptr t level :
     forall root_ptr idxs,
       In idxs (index_sequences_to_pointer'' deref ptr root_ptr level) ->
@@ -1025,27 +1089,6 @@ Section Proofs.
     cbn [reassign_pointer ptable_deref].
     erewrite changed_has_new_attrs; solver.
   Qed.
-
-  (* TODO : move *)
-  Lemma vm_find_Some v : In v vms -> vm_find (vm_id v) = Some v.
-  Admitted. (* TODO *)
-  Hint Resolve vm_find_Some.
-
-  (* TODO : move *)
-  Lemma vm_find_sound v vid : vm_find vid = Some v -> vm_id v = vid.
-  Admitted. (* TODO *)
-  Hint Resolve vm_find_sound.
-
-  Lemma vm_find_unique_entity v1 v2 vid :
-    vm_find vid = Some v2 ->
-    v1 <> v2 ->
-    ~ (@eq entity_id (inl vid) (inl (vm_id v1))).
-  Admitted. (* TODO *)
-  Hint Resolve vm_find_unique_entity.
-
-  Lemma vm_find_In vid v : vm_find vid = Some v -> In v vms.
-  Admitted. (* TODO *)
-  Hint Resolve vm_find_In.
 
   Local Ltac solve_table_unchanged_step :=
     first [ eapply vm_table_unchanged_stage2; solver

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -321,6 +321,15 @@ Section FoldLeft.
     generalize dependent b; induction ls; intros;
       cbn [fold_left]; eauto.
   Qed.
+
+  Lemma fold_left_invariant_strong (P : B -> Prop) (f : B -> A -> B) b ls :
+    (forall a b, In a ls -> P b -> P (f b a)) ->
+    P b ->
+    P (fold_left f ls b).
+  Proof.
+    generalize dependent b; induction ls; intros;
+      cbn [fold_left]; eauto.
+  Qed.
 End FoldLeft.
 
 (* Proofs about [filter] *)
@@ -350,6 +359,15 @@ Section FirstnSkipn.
     cbn [firstn]. destruct i; [reflexivity|].
     rewrite IHls by solver.
     reflexivity.
+  Qed.
+
+  Lemma firstn_app_l (l1 : list A) :
+    forall l2 n, n <= length l1 -> firstn n (l1 ++ l2) = firstn n l1.
+  Proof.
+    induction l1; destruct n; basics;
+      rewrite <-?app_comm_cons, ?firstn_cons;
+      autorewrite with push_length in *;
+      rewrite ?IHl1; try solver.
   Qed.
 
   Lemma in_firstn (a : A) ls : forall i, In a (firstn i ls) -> In a ls.
@@ -407,6 +425,8 @@ End FirstnSkipn.
 
 (* autorewrite databases for [firstn] and [skipn] *)
 Hint Rewrite @firstn_O @firstn_nil @firstn_cons : push_firstn.
+Hint Rewrite @firstn_app_l @firstn_all2 @firstn_firstn
+     using (autorewrite with push_length; solver) : push_firstn.
 Hint Rewrite @skipn_nil @skipn_cons : push_skipn.
 Hint Rewrite @skipn_all using lia : push_skipn.
 Hint Rewrite @skipn_length : push_length.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -70,6 +70,7 @@ Section App.
   Lemma app_not_nil_r (l1 l2 : list A) : l2 <> nil -> l1 ++ l2 <> nil.
   Proof.  destruct l1; cbn [app]; solver. Qed.
 End App.
+Hint Rewrite @app_nil_l @app_nil_r : push_app.
 
 (* Proofs about [seq] *)
 Section Seq.


### PR DESCRIPTION
Over the last few days I've been working a lot on the sublemmas left over by `reassign_pointer_represents`, and the depth-first strategy is taking a long time. So, instead, I'm taking a more "breadth-first" approach, and proving these lemmas against admits at a lower abstraction level (in this case, the abstraction level of page tables as described in `PageTables.v` and `PointerLocations.v`). This PR proves all of the `reassign_pointer_represents` sublemmas against three admitted lemmas : `page_lookup_update_deref`, `page_table_lookup_equiv`, and `has_location_table_lookup`. (I also left `address_matches_indices_iff`, because I expect it to be straightforward but annoying to prove and this PR was big enough already.)

I also leave several admitted lemmas in `PointerLocations.v` that are not currently used anywhere but will probably be helpful in proving the three admitted lemmas at that abstraction level. There are also some indentation changes in `PointerLocations.v` that don't alter the code.