### PR TITLE
Wrapping up state-change proofs

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -77,8 +77,13 @@ Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 P
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
+
 (* arch_mm_pte_is_valid is true iff [ attrs & PTE_VALID != 0 ] *)
 Axiom is_valid_matches_flag :
   forall pte level,
     let attrs := arch_mm_pte_attrs pte level in
     arch_mm_pte_is_valid pte level = negb (N.eqb (N.land attrs PTE_VALID) 0).
+
+(* The attributes of absent PTEs are always the same *)
+Axiom absent_attrs : attributes.
+Axiom absent_pte_attrs : forall level, arch_mm_pte_attrs (arch_mm_absent_pte level) level = absent_attrs.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -495,8 +495,8 @@ Fixpoint mm_map_level
                        */ *)
            if ((if unmap
                 then !arch_mm_pte_is_present pte level
-                else arch_mm_pte_is_block pte level)
-                 && (arch_mm_pte_attrs pte level =? attrs)%N)%bool
+                else (arch_mm_pte_is_block pte level)
+                       && (arch_mm_pte_attrs pte level =? attrs))%N)%bool
            then
              (* done; continue to the next entry *)
              (* begin = mm_start_of_next_block(begin, entry_size);

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -582,41 +582,41 @@ Fixpoint mm_map_level
                      (s, begin, pa, table, pte_index, failed, ppool, break)
                    | (true, nt, s, ppool) =>
 
-                 (* /*
-                  * If the subtable is now empty, replace it with an
-                  * absent entry at this level. We never need to do
-                  * break-before-makes here because we are assigning
-                  * an absent value.
-                  */
-                     if (commit && unmap &&
-                         mm_page_table_is_empty(nt, level - 1)) {
-                             pte_t v = *pte;
-                             *pte = arch_mm_absent_pte(level);
-                             mm_free_page_pte(v, level, ppool);
-                     } *)
-                 let '(pte, s, ppool) :=
-                     if (commit && unmap &&
-                                mm_page_table_is_empty nt (level - 1))%bool
-                     then
-                       let v := pte in
-                       (* N.B. in functional programming we can't edit data under
-                          a pointer, so we need to construct a new table and pass
-                          it along. *)
-                       let table :=
-                           table.(mm_page_table_replace_entry)
-                                   (arch_mm_absent_pte level) pte_index in
-                       let '(s, ppool) := mm_free_page_pte s v level ppool in
-                       (pte, s, ppool)
-                     else (pte, s, ppool) in
-                 (* done; continue to the next entry *)
-                 (* begin = mm_start_of_next_block(begin, entry_size);
-                    pa = mm_pa_start_of_next_block(pa, entry_size);
-                    pte++; *)
-                 let begin := mm_start_of_next_block begin entry_size in
-                 let pa := mm_pa_start_of_next_block pa entry_size in
-                 let pte_index := S pte_index in
-                 (s, begin, pa, table, pte_index, failed, ppool, continue)
-               end end end) in
+                    (* /*
+                     * If the subtable is now empty, replace it with an
+                     * absent entry at this level. We never need to do
+                     * break-before-makes here because we are assigning
+                     * an absent value.
+                     */
+                        if (commit && unmap &&
+                            mm_page_table_is_empty(nt, level - 1)) {
+                                pte_t v = *pte;
+                                *pte = arch_mm_absent_pte(level);
+                                mm_free_page_pte(v, level, ppool);
+                        } *)
+                     let '(pte, s, ppool) :=
+                         if (commit && unmap &&
+                                    mm_page_table_is_empty nt (level - 1))%bool
+                         then
+                           let v := pte in
+                          (* N.B. in functional programming we can't edit data under
+                             a pointer, so we need to construct a new table and pass
+                             it along. *)
+                          let table :=
+                              table.(mm_page_table_replace_entry)
+                                      (arch_mm_absent_pte level) pte_index in
+                          let '(s, ppool) := mm_free_page_pte s v level ppool in
+                          (pte, s, ppool)
+                        else (pte, s, ppool) in
+                    (* done; continue to the next entry *)
+                    (* begin = mm_start_of_next_block(begin, entry_size);
+                       pa = mm_pa_start_of_next_block(pa, entry_size);
+                       pte++; *)
+                    let begin := mm_start_of_next_block begin entry_size in
+                    let pa := mm_pa_start_of_next_block pa entry_size in
+                    let pte_index := S pte_index in
+                    (s, begin, pa, table, pte_index, failed, ppool, continue)
+                  end end end) in
 
   (* return true; *)
   (* N.B. have to check here if the loop returned false partway through *)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -464,7 +464,7 @@ Section Proofs.
   Proof.
     intro H. cbv [is_root] in H; rewrite H; intros.
     cbv [address_matches_indices]; autorewrite with push_length; intro i.
-    destruct i; [basics|solver].
+    destruct i; basics; [|solver].
     autorewrite with push_nth_default.
     rewrite index_of_uintvaddr by solver.
     rewrite Nat.sub_0_r, mm_max_level_eq.

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -531,19 +531,19 @@ Section Proofs.
      translation it returns a new table to the caller and the caller updates the
      state) *)
   Lemma mm_map_level_represents
-        (conc : concrete_state)
-        begin end_ pa attrs table level flags ppool :
-    (snd (fst (mm_map_level
-                 conc begin end_ pa attrs table level flags ppool))) = conc.
+        (conc : concrete_state) level :
+    forall begin end_ pa attrs table flags ppool,
+             (snd (fst (mm_map_level
+                          conc begin end_ pa attrs table level flags ppool))) = conc.
   Proof.
-    autounfold; cbv [mm_map_level].
-    repeat match goal with
-           | _ => simplify_step
-           | _ => apply while_loop_invariant; [ | solver ]
-           | _ => rewrite mm_free_page_pte_represents
-           | _ => rewrite mm_replace_entry_represents
-           | _ => rewrite mm_populate_table_pte_represents
-           end.
+    induction level; autounfold; cbn [mm_map_level];
+      repeat match goal with
+             | _ => simplify_step
+             | _ => apply while_loop_invariant; [ | solver ]
+             | _ => rewrite mm_free_page_pte_represents
+             | _ => rewrite mm_replace_entry_represents
+             | _ => rewrite mm_populate_table_pte_represents
+             end.
   Qed.
 
   Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -56,7 +56,10 @@ Section Proofs.
     abstract_state_equiv abst abst' ->
     represents abst conc ->
     represents abst' conc.
-  Admitted.
+  Proof.
+    intro Hequiv. destruct Hequiv as [Hown Haccess].
+    cbv [represents]; basics; rewrite <-?Hown, <-?Haccess; solver.
+  Qed.
 
   (* [represents] includes [is_valid] as one of its conditions *)
   Lemma represents_valid_concrete conc : (exists abst, represents abst conc) -> is_valid conc.

--- a/coq-verification/src/Util/List.v
+++ b/coq-verification/src/Util/List.v
@@ -321,6 +321,15 @@ Section FoldLeft.
     generalize dependent b; induction ls; intros;
       cbn [fold_left]; eauto.
   Qed.
+
+  Lemma fold_left_invariant_strong (P : B -> Prop) (f : B -> A -> B) b ls :
+    (forall a b, In a ls -> P b -> P (f b a)) ->
+    P b ->
+    P (fold_left f ls b).
+  Proof.
+    generalize dependent b; induction ls; intros;
+      cbn [fold_left]; eauto.
+  Qed.
 End FoldLeft.
 
 (* Proofs about [filter] *)
@@ -350,6 +359,15 @@ Section FirstnSkipn.
     cbn [firstn]. destruct i; [reflexivity|].
     rewrite IHls by solver.
     reflexivity.
+  Qed.
+
+  Lemma firstn_app_l (l1 : list A) :
+    forall l2 n, n <= length l1 -> firstn n (l1 ++ l2) = firstn n l1.
+  Proof.
+    induction l1; destruct n; basics;
+      rewrite <-?app_comm_cons, ?firstn_cons;
+      autorewrite with push_length in *;
+      rewrite ?IHl1; try solver.
   Qed.
 
   Lemma in_firstn (a : A) ls : forall i, In a (firstn i ls) -> In a ls.
@@ -407,6 +425,8 @@ End FirstnSkipn.
 
 (* autorewrite databases for [firstn] and [skipn] *)
 Hint Rewrite @firstn_O @firstn_nil @firstn_cons : push_firstn.
+Hint Rewrite @firstn_app_l @firstn_all2 @firstn_firstn
+     using (autorewrite with push_length; solver) : push_firstn.
 Hint Rewrite @skipn_nil @skipn_cons : push_skipn.
 Hint Rewrite @skipn_all using lia : push_skipn.
 Hint Rewrite @skipn_length : push_length.


### PR DESCRIPTION
On top of #53 

This PR proves all the remaining sublemmas about state changes against the three page-table-level admits described in #53. From here, I'll move on to `mm_map_level` proofs.