### PR TITLE
Fix mm_map_level implementation

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -77,8 +77,13 @@ Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 P
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
+
 (* arch_mm_pte_is_valid is true iff [ attrs & PTE_VALID != 0 ] *)
 Axiom is_valid_matches_flag :
   forall pte level,
     let attrs := arch_mm_pte_attrs pte level in
     arch_mm_pte_is_valid pte level = negb (N.eqb (N.land attrs PTE_VALID) 0).
+
+(* The attributes of absent PTEs are always the same *)
+Axiom absent_attrs : attributes.
+Axiom absent_pte_attrs : forall level, arch_mm_pte_attrs (arch_mm_absent_pte level) level = absent_attrs.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -495,8 +495,8 @@ Fixpoint mm_map_level
                        */ *)
            if ((if unmap
                 then !arch_mm_pte_is_present pte level
-                else arch_mm_pte_is_block pte level)
-                 && (arch_mm_pte_attrs pte level =? attrs)%N)%bool
+                else (arch_mm_pte_is_block pte level)
+                       && (arch_mm_pte_attrs pte level =? attrs))%N)%bool
            then
              (* done; continue to the next entry *)
              (* begin = mm_start_of_next_block(begin, entry_size);

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -582,41 +582,41 @@ Fixpoint mm_map_level
                      (s, begin, pa, table, pte_index, failed, ppool, break)
                    | (true, nt, s, ppool) =>
 
-                 (* /*
-                  * If the subtable is now empty, replace it with an
-                  * absent entry at this level. We never need to do
-                  * break-before-makes here because we are assigning
-                  * an absent value.
-                  */
-                     if (commit && unmap &&
-                         mm_page_table_is_empty(nt, level - 1)) {
-                             pte_t v = *pte;
-                             *pte = arch_mm_absent_pte(level);
-                             mm_free_page_pte(v, level, ppool);
-                     } *)
-                 let '(pte, s, ppool) :=
-                     if (commit && unmap &&
-                                mm_page_table_is_empty nt (level - 1))%bool
-                     then
-                       let v := pte in
-                       (* N.B. in functional programming we can't edit data under
-                          a pointer, so we need to construct a new table and pass
-                          it along. *)
-                       let table :=
-                           table.(mm_page_table_replace_entry)
-                                   (arch_mm_absent_pte level) pte_index in
-                       let '(s, ppool) := mm_free_page_pte s v level ppool in
-                       (pte, s, ppool)
-                     else (pte, s, ppool) in
-                 (* done; continue to the next entry *)
-                 (* begin = mm_start_of_next_block(begin, entry_size);
-                    pa = mm_pa_start_of_next_block(pa, entry_size);
-                    pte++; *)
-                 let begin := mm_start_of_next_block begin entry_size in
-                 let pa := mm_pa_start_of_next_block pa entry_size in
-                 let pte_index := S pte_index in
-                 (s, begin, pa, table, pte_index, failed, ppool, continue)
-               end end end) in
+                    (* /*
+                     * If the subtable is now empty, replace it with an
+                     * absent entry at this level. We never need to do
+                     * break-before-makes here because we are assigning
+                     * an absent value.
+                     */
+                        if (commit && unmap &&
+                            mm_page_table_is_empty(nt, level - 1)) {
+                                pte_t v = *pte;
+                                *pte = arch_mm_absent_pte(level);
+                                mm_free_page_pte(v, level, ppool);
+                        } *)
+                     let '(pte, s, ppool) :=
+                         if (commit && unmap &&
+                                    mm_page_table_is_empty nt (level - 1))%bool
+                         then
+                           let v := pte in
+                          (* N.B. in functional programming we can't edit data under
+                             a pointer, so we need to construct a new table and pass
+                             it along. *)
+                          let table :=
+                              table.(mm_page_table_replace_entry)
+                                      (arch_mm_absent_pte level) pte_index in
+                          let '(s, ppool) := mm_free_page_pte s v level ppool in
+                          (pte, s, ppool)
+                        else (pte, s, ppool) in
+                    (* done; continue to the next entry *)
+                    (* begin = mm_start_of_next_block(begin, entry_size);
+                       pa = mm_pa_start_of_next_block(pa, entry_size);
+                       pte++; *)
+                    let begin := mm_start_of_next_block begin entry_size in
+                    let pa := mm_pa_start_of_next_block pa entry_size in
+                    let pte_index := S pte_index in
+                    (s, begin, pa, table, pte_index, failed, ppool, continue)
+                  end end end) in
 
   (* return true; *)
   (* N.B. have to check here if the loop returned false partway through *)

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -531,19 +531,19 @@ Section Proofs.
      translation it returns a new table to the caller and the caller updates the
      state) *)
   Lemma mm_map_level_represents
-        (conc : concrete_state)
-        begin end_ pa attrs table level flags ppool :
-    (snd (fst (mm_map_level
-                 conc begin end_ pa attrs table level flags ppool))) = conc.
+        (conc : concrete_state) level :
+    forall begin end_ pa attrs table flags ppool,
+             (snd (fst (mm_map_level
+                          conc begin end_ pa attrs table level flags ppool))) = conc.
   Proof.
-    autounfold; cbv [mm_map_level].
-    repeat match goal with
-           | _ => simplify_step
-           | _ => apply while_loop_invariant; [ | solver ]
-           | _ => rewrite mm_free_page_pte_represents
-           | _ => rewrite mm_replace_entry_represents
-           | _ => rewrite mm_populate_table_pte_represents
-           end.
+    induction level; autounfold; cbn [mm_map_level];
+      repeat match goal with
+             | _ => simplify_step
+             | _ => apply while_loop_invariant; [ | solver ]
+             | _ => rewrite mm_free_page_pte_represents
+             | _ => rewrite mm_replace_entry_represents
+             | _ => rewrite mm_populate_table_pte_represents
+             end.
   Qed.
 
   Lemma mm_map_level_table_attrs conc begin end_ pa attrs table level


### PR DESCRIPTION
On top of #54 

I realized that in the original transcription of `mm_map_level`, I mistakenly omitted a chunk of code. This PR adds that code and fixes up an existing proof to match it.

Best reviewed commit-by-commit, since the middle commit is just indentation fixes.