### PR TITLE
Partial proof of mm_map_level_attrs

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -77,8 +77,13 @@ Axiom stage1_root_table_count_ok : arch_mm_stage1_root_table_count < Nat.pow 2 P
 Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 PAGE_LEVEL_BITS.
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
+
 (* arch_mm_pte_is_valid is true iff [ attrs & PTE_VALID != 0 ] *)
 Axiom is_valid_matches_flag :
   forall pte level,
     let attrs := arch_mm_pte_attrs pte level in
     arch_mm_pte_is_valid pte level = negb (N.eqb (N.land attrs PTE_VALID) 0).
+
+(* The attributes of absent PTEs are always the same *)
+Axiom absent_attrs : attributes.
+Axiom absent_pte_attrs : forall level, arch_mm_pte_attrs (arch_mm_absent_pte level) level = absent_attrs.

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -495,8 +495,8 @@ Fixpoint mm_map_level
                        */ *)
            if ((if unmap
                 then !arch_mm_pte_is_present pte level
-                else arch_mm_pte_is_block pte level)
-                 && (arch_mm_pte_attrs pte level =? attrs)%N)%bool
+                else (arch_mm_pte_is_block pte level)
+                       && (arch_mm_pte_attrs pte level =? attrs))%N)%bool
            then
              (* done; continue to the next entry *)
              (* begin = mm_start_of_next_block(begin, entry_size);


### PR DESCRIPTION
On top of #55 

I'm starting to work on the `mm_map_level` proofs. This PR contains half of the main proof for `mm_map_level`, which states that the returned table is the same as the original but with the attributes of PTEs in the given range changed in the correct way.