### PR TITLE
Set up invariant structure for mm_map_level, most of proof

### DIFF
--- a/coq-verification/src/Concrete/Assumptions/ArchMM.v
+++ b/coq-verification/src/Concrete/Assumptions/ArchMM.v
@@ -78,6 +78,14 @@ Axiom stage2_root_table_count_ok : arch_mm_stage2_root_table_count < Nat.pow 2 P
 Axiom stage1_max_level_pos : 0 < arch_mm_stage1_max_level.
 Axiom stage2_max_level_pos : 0 < arch_mm_stage2_max_level.
 
+(* absent and block PTEs are not tables *)
+Axiom absent_not_table :
+  forall level,
+    arch_mm_pte_is_table (arch_mm_absent_pte level) level = false.
+Axiom block_not_table :
+  forall level pa attrs,
+    arch_mm_pte_is_table (arch_mm_block_pte level pa attrs) level = false.
+
 (* shorthand definitions just for this file to make axiom statements neater *)
 Local Notation get_bit n bit := (negb (N.eqb (N.land n bit) 0)). (* (n & bit) != 0 *)
 

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -50,3 +50,25 @@ Axiom mpool_alloc_contiguous :
    exist purely conceptually *)
 Axiom mpool_contains : mpool -> ptable_pointer -> Prop.
 Axiom mpool_fallback : mpool -> option mpool. (* returns fallback if there is one *)
+
+(* if [mpool_alloc] returns [Some], then the pool must have contained the
+   returned pointer before the call, and must not contain it afterwards *)
+Axiom mpool_alloc_contains_before :
+  forall ppool ppool' ptr,
+    mpool_alloc ppool = Some (ppool', ptr) ->
+    mpool_contains ppool ptr.
+Axiom mpool_alloc_contains_after :
+  forall ppool ppool' ptr,
+    mpool_alloc ppool = Some (ppool', ptr) ->
+    ~ mpool_contains ppool' ptr.
+
+(* If an mpool has a fallback, then allocating from it either means allocating
+   from the fallback or not changing the fallback *)
+Axiom mpool_alloc_fallback :
+  forall ppool ppool' new_ptr fallback,
+    mpool_fallback ppool = Some fallback ->
+    mpool_alloc ppool = Some (ppool', new_ptr) ->
+    mpool_fallback ppool' = Some fallback \/
+    (exists fallback',
+        mpool_alloc fallback = Some (fallback', new_ptr)
+        /\ mpool_fallback ppool' = Some fallback').

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -72,3 +72,9 @@ Axiom mpool_alloc_fallback :
     (exists fallback',
         mpool_alloc fallback = Some (fallback', new_ptr)
         /\ mpool_fallback ppool' = Some fallback').
+
+(* Freeing is simpler; it doesn't ever change the fallback because memory is
+   freed into the local pool *)
+Axiom mpool_free_fallback :
+  forall ppool ptr,
+    mpool_fallback (mpool_free ppool ptr) = mpool_fallback ppool.

--- a/coq-verification/src/Concrete/Assumptions/Mpool.v
+++ b/coq-verification/src/Concrete/Assumptions/Mpool.v
@@ -46,7 +46,7 @@ Axiom mpool_free : mpool -> ptable_pointer -> mpool.
 Axiom mpool_alloc_contiguous :
   mpool -> size_t -> size_t -> option (mpool * list ptable_pointer).
 
-
-(* N.B. this is for proofs, not code; it's not part of the header file and exists
-   purely conceptually *)
+(* N.B. these are for proofs, not code; they are not part of the header file and
+   exist purely conceptually *)
 Axiom mpool_contains : mpool -> ptable_pointer -> Prop.
+Axiom mpool_fallback : mpool -> option mpool. (* returns fallback if there is one *)

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -350,6 +350,16 @@ Definition mm_populate_table_pte
       let ntable_ptr := hd null_pointer ntable_ptr_list in
       let ntable := s.(ptable_deref) ntable_ptr in
 
+      (* Functional-program bookkeeping : mm_alloc_page_tables could have edited
+         the api_page_pool, so we need to update it. Assumes api_page_pool is
+         the fallback of ppool. *)
+      let s :=
+          match mpool_fallback ppool with
+          | None => s
+          | Some new_api_page_pool =>
+            s.(update_page_pool) new_api_page_pool
+          end in
+
       (* /* Determine template for new pte and its increment. */
          if (arch_mm_pte_is_block(v, level)) {
                  inc = mm_entry_size(level_below);

--- a/coq-verification/src/Concrete/MM/Implementation.v
+++ b/coq-verification/src/Concrete/MM/Implementation.v
@@ -586,7 +586,8 @@ Fixpoint mm_map_level
                   } *)
                  match level with
                  | O =>
-                   (* shouldn't happen; no table entries at level 0 *)
+                   (* shouldn't happen; if we're at level 0, end_ can't be
+                      partway through a block *)
                    let failed := true in
                    (s, begin, pa, table, pte_index, failed, ppool, break)
                  | S level_minus1 =>

--- a/coq-verification/src/Concrete/MM/Proofs.v
+++ b/coq-verification/src/Concrete/MM/Proofs.v
@@ -688,54 +688,6 @@ Section Proofs.
 
   (*** Proofs about [mm_map_level] ***)
 
-  Definition is_while_loop_value {state} value end_value cond body : Prop :=
-    (* value is < end_value iff cond is true *)
-    (forall s : state, cond s = (value s <? end_value))
-    (* ...and value decreases monotonically *)
-    /\ (forall s : state, snd (body s) = continue -> value s < value (fst (body s))).
-
-  Definition is_while_loop_success {state} successful body : Prop :=
-    (* the success metric never goes from false to true *)
-    (forall s : state, successful s = false -> successful (fst (body s)) = false)
-    (* ...and success implies that the loop continues *)
-    /\ (forall s : state, successful (fst (body s)) = true -> snd (body s) = continue).
-
-  Definition is_while_loop_invariant
-             {state} (inv : state -> Prop) successful cond body : Prop :=
-    (* the loop only breaks when the continuation condition or success condition
-       is false anyway -- this guarantees that if successful = true, the loop
-       completed *)
-    (forall s, cond s = true -> inv s ->
-               snd (body s) = continue
-               \/ cond (fst (body s)) = false
-               \/ successful (fst (body s)) = false)
-    (* ...and invariant holds over loop *)
-    /\ (forall s : state, cond s = true -> inv s -> inv (fst (body s))).
-
-  (* TODO *)
-  Lemma while_loop_invariant_strong
-        {state} (inv P : state -> Prop) (successful : state -> bool)
-        (value : state -> nat) (end_value : nat)
-        max_iterations cond body start :
-    is_while_loop_value value end_value cond body ->
-    is_while_loop_success successful body ->
-    is_while_loop_invariant inv successful cond body ->
-    (* we have enough fuel *)
-    end_value - value start <= max_iterations ->
-    (* invariant holds at start *)
-    inv start ->
-    (* invariant implies conclusion *)
-    (forall s, inv s -> (cond s = false \/ successful s = false) -> P s) ->
-    P (while_loop (max_iterations:=max_iterations) cond start body).
-  Proof.
-    cbv [is_while_loop_value is_while_loop_success is_while_loop_invariant]; basics.
-    match goal with H : _ |- _ => apply H end.
-    { apply while_loop_invariant; eauto. }
-    { match goal with |- context [successful ?s] =>
-                      case_eq (successful s); basics; try solver end.
-      left. eapply while_loop_completed; eauto. }
-  Qed.
-
   (* TODO : move *)
   Lemma page_attrs'_absent deref t a level stage :
     arch_mm_pte_is_present (nth_default_oobe (entries t) (mm_index a level)) level = false ->

--- a/coq-verification/src/Concrete/State.v
+++ b/coq-verification/src/Concrete/State.v
@@ -57,6 +57,14 @@ Definition reassign_pointer
     api_page_pool := s.(api_page_pool);
   |}.
 
+Definition update_page_pool
+           (s : concrete_state) (new_pool : mpool)
+  : concrete_state :=
+  {|
+    ptable_deref := s.(ptable_deref);
+    api_page_pool := new_pool;
+  |}.
+
 Definition is_valid {cp : concrete_params} (s : concrete_state) : Prop :=
   locations_exclusive s.(ptable_deref) s.(api_page_pool)
   /\ Forall (root_ptable_wf s.(ptable_deref) Stage2) (map vm_ptable vms)

--- a/coq-verification/src/Concrete/StateProofs.v
+++ b/coq-verification/src/Concrete/StateProofs.v
@@ -1523,7 +1523,6 @@ Section Proofs.
     locations_exclusive (update_deref deref ptr t) ppool'.
   Proof.
     cbv [locations_exclusive]; basics.
-    Search has_location update_deref.
     invert H.
     (* actually, there are no new pointers added here... *)
     (* TODO *)


### PR DESCRIPTION
In the last PR, I was working on the first big `mm_map_level` proof and had proven the first of two cases (the case in which `level = 0`). However, when I tried to prove the `level > 0` case, I ran into problems. Because `mm_map_level` is a recursive function, I need to use induction to reason about its properties (i.e. I prove that something is true when `level = 0`, and then assuming it's true for `level` I prove it's true for `level + 1`). But `mm_map_level` also has a while loop in it, so I have to use a loop invariant (i.e. prove that there exists an invariant which holds for the initial values and holds after the loop body assuming it held beforehand, and that that invariant is sufficient to prove my goal). This double structure creates problems; when I'm trying to prove the loop invariant holds, I need to prove things about my recursive call, and the inductive hypothesis won't have all of the information that is needed to prove the loop invariant since the loop invariant has a lot more information than any one goal.

I've solved this problem by a) proving an extra lemma about while loops that makes applying invariants easier, b) proving a lemma by induction stating that if the loop invariant for `mm_map_level` was in fact an invariant, then you could use it to prove weaker statements, c) using (b) to prove that `mm_map_level`'s loop invariant was a valid loop invariant, and d) using (b) and (c) to prove that the loop invariant could be used to prove weaker statements. This required a fair bit of Coq wizardry, including extracting the loop body from the definition of `mm_map_level`.

The result of all this work is that all of the `mm_map_level` proofs should just follow from the proof of the invariant; that means that instead of doing induction and proving invariants for every single proof, I do it once and then I can prove anything that the invariant implies, which significantly simplifies the `mm_map_level` proof task.

I also found a transcription error that required some changes to the proofs about `mm_populate_table_pte` and other mid-level `mm.c` functions (the error was that I wasn't properly updating the global state after an allocation that might have touched the global fallback page pool, and not updating data under a pointer for `mm_populate_table_pte`). The main resulting complication is that, to accommodate `mm_populate_table_pte` changing table structure but not attributes, I need to write an equivalence relation between concrete states that isn't literal equality and use it in the `mm_map_root` proof.

There are still some admits peppered through here, but the general structure is now stable, and it had gotten to be enough code that a PR was warranted.